### PR TITLE
Update dependency redux to v4

### DIFF
--- a/Examples/xc.chat/webapp/package.json
+++ b/Examples/xc.chat/webapp/package.json
@@ -61,7 +61,7 @@
     "react-router": "^3.0.0",
     "react-scroll-collapse": "^0.2.0",
     "reactivexcomponent.js": "^3.1.8",
-    "redux": "^3.6.0",
+    "redux": "^4.0.0",
     "redux-logger": "^3.0.0",
     "redux-saga": "^0.16.0",
     "redux-thunk": "^2.2.0",

--- a/Examples/xc.chat/webapp/yarn.lock
+++ b/Examples/xc.chat/webapp/yarn.lock
@@ -4933,7 +4933,7 @@ locate-path@^3.0.0:
     p-locate "^3.0.0"
     path-exists "^3.0.0"
 
-lodash-es@^4.2.0, lodash-es@^4.2.1:
+lodash-es@^4.2.0:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.4.tgz#dcc1d7552e150a0640073ba9cb31d70f032950e7"
 
@@ -5060,7 +5060,7 @@ lodash.zip@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/lodash.zip/-/lodash.zip-4.2.0.tgz#ec6662e4896408ed4ab6c542a3990b72cc080020"
 
-lodash@^4.0.0, lodash@^4.14.0, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.2.1, lodash@~4.17.4:
+lodash@^4.0.0, lodash@^4.14.0, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.2.0, lodash@~4.17.4:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
@@ -6675,15 +6675,6 @@ redux-thunk@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/redux-thunk/-/redux-thunk-2.2.0.tgz#e615a16e16b47a19a515766133d1e3e99b7852e5"
 
-redux@^3.6.0:
-  version "3.7.2"
-  resolved "https://registry.yarnpkg.com/redux/-/redux-3.7.2.tgz#06b73123215901d25d065be342eb026bc1c8537b"
-  dependencies:
-    lodash "^4.2.1"
-    lodash-es "^4.2.1"
-    loose-envify "^1.1.0"
-    symbol-observable "^1.0.3"
-
 redux@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/redux/-/redux-4.0.0.tgz#aa698a92b729315d22b34a0553d7e6533555cc03"
@@ -7715,10 +7706,6 @@ svgo@^1.0.0:
     stable "~0.1.6"
     unquote "~1.1.1"
     util.promisify "~1.0.0"
-
-symbol-observable@^1.0.3:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.0.4.tgz#29bf615d4aa7121bdd898b22d4b3f9bc4e2aa03d"
 
 symbol-observable@^1.2.0:
   version "1.2.0"


### PR DESCRIPTION
<p>This Pull Request updates dependency <a href="https://renovatebot.com/gh/reactjs/redux">redux</a> from <code>^3.6.0</code> to <code>^4.0.0</code></p>
<p><details><br />
<summary>Release Notes</summary></p>
<h3 id="v400httpsgithubcomreactjsreduxreleasesv400"><a href="https://renovatebot.com/gh/reactjs/redux/releases/v4.0.0">v4.0.0</a></h3>
<p><a href="https://renovatebot.com/gh/reactjs/redux/compare/v3.7.2…v4.0.0">Compare Source</a><br />
Redux 4 is here! 🎉</p>
<p>If you're a React user, this is going to be a lot like going from 15 to 16. Not a lot of user-facing changes, but some interesting improvements under the hood. </p>
<p>The major changes (<a href="https://renovatebot.com/gh/reactjs/redux/issues/1342">#&#8203;1342</a>) are around our TypeScript definitions, bundled CommonJS and ES builds, throwing if you subscribe or getState from a reducer, and a bunch of other smaller things. The full changes are listed below.</p>
<p>Enjoy!</p>
<h4 id="changeshttpsgithubcomreactjsreduxcomparev372v400"><a href="https://renovatebot.com/gh/reactjs/redux/compare/v3.7.2…v4.0.0">Changes</a></h4>
<ul>
<li>Tons of docs updates. Thanks <a href="https://renovatebot.com/gh/markerikson">@&#8203;markerikson</a> and the Redux community for all your PRs!</li>
<li>Make middleware API dispatch pass through all call arguments (<a href="https://renovatebot.com/gh/reactjs/redux/issues/2560">#&#8203;2560</a> by <a href="https://renovatebot.com/gh/Asvarox">@&#8203;Asvarox</a>)</li>
<li>Refactor applyMiddleware to reduce confusion around createStore args (<a href="https://renovatebot.com/gh/reactjs/redux/issues/2201">#&#8203;2201</a> by <a href="https://renovatebot.com/gh/jimbolla">@&#8203;jimbolla</a>)</li>
<li>Make bindActionCreators transparently pass <code>this</code> (<a href="https://renovatebot.com/gh/reactjs/redux/issues/2641">#&#8203;2641</a> by <a href="https://renovatebot.com/gh/Parakleta">@&#8203;Parakleta</a>)</li>
<li>Remove <a href="https://renovatebot.com/gh/private">@&#8203;private</a> flag on AnyAction type definition (<a href="https://renovatebot.com/gh/reactjs/redux/issues/2510">#&#8203;2510</a> by <a href="https://renovatebot.com/gh/alexmngn">@&#8203;alexmngn</a>)</li>
<li>Fixed quote types inconsistency in a warning message (<a href="https://renovatebot.com/gh/reactjs/redux/issues/2297">#&#8203;2297</a> by <a href="https://renovatebot.com/gh/Andarist">@&#8203;Andarist</a>)</li>
<li>Move ActionTypes to a private export (<a href="https://renovatebot.com/gh/reactjs/redux/commit/b62248b"><code>b62248b</code></a> by <a href="https://renovatebot.com/gh/timdorr">@&#8203;timdorr</a>)</li>
<li>Throw if getState, subscribe, or unsubscribe called while dispatching (<a href="https://renovatebot.com/gh/reactjs/redux/issues/1569">#&#8203;1569</a> by <a href="https://renovatebot.com/gh/mjw56">@&#8203;mjw56</a>)</li>
<li>Warn when dispatching during Middleware setup (<a href="https://renovatebot.com/gh/reactjs/redux/issues/1485">#&#8203;1485</a> by <a href="https://renovatebot.com/gh/timdorr">@&#8203;timdorr</a>)</li>
<li>Mapped type for combineReducers in index.d.ts (<a href="https://renovatebot.com/gh/reactjs/redux/issues/2182">#&#8203;2182</a> by <a href="https://renovatebot.com/gh/mkusher">@&#8203;mkusher</a>)</li>
<li>Remove legacy jsnext entry (<a href="https://renovatebot.com/gh/reactjs/redux/issues/2284">#&#8203;2284</a> by <a href="https://renovatebot.com/gh/TrySound">@&#8203;TrySound</a>)</li>
<li>Revamp TypeScript typing with more type safety (<a href="https://renovatebot.com/gh/reactjs/redux/issues/2563">#&#8203;2563</a> by <a href="https://renovatebot.com/gh/pelotom">@&#8203;pelotom</a>)</li>
<li>Fix TS definitions test for new Dispatch typing (<a href="https://renovatebot.com/gh/reactjs/redux/issues/2674">#&#8203;2674</a> by <a href="https://renovatebot.com/gh/pelotom">@&#8203;pelotom</a>)</li>
<li>Add DeepPartial type for preloaded state (<a href="https://renovatebot.com/gh/reactjs/redux/issues/2679">#&#8203;2679</a> by <a href="https://renovatebot.com/gh/aikoven">@&#8203;aikoven</a>)</li>
<li>Bundle cjs and es formats (<a href="https://renovatebot.com/gh/reactjs/redux/issues/2358">#&#8203;2358</a> by <a href="https://renovatebot.com/gh/TrySound">@&#8203;TrySound</a>)</li>
<li>REPLACE action for replaceReducers (<a href="https://renovatebot.com/gh/reactjs/redux/issues/2673">#&#8203;2673</a> by <a href="https://renovatebot.com/gh/timdorr">@&#8203;timdorr</a>)</li>
<li>Update build to use babel-preset-env (<a href="https://renovatebot.com/gh/reactjs/redux/issues/2696">#&#8203;2696</a> by <a href="https://renovatebot.com/gh/hmillison">@&#8203;hmillison</a>)</li>
<li>Optimize dispatch plain object check (<a href="https://renovatebot.com/gh/reactjs/redux/issues/2599">#&#8203;2599</a> by <a href="https://renovatebot.com/gh/timdorr">@&#8203;timdorr</a>)</li>
<li>Update TypeScript typings (<a href="https://renovatebot.com/gh/reactjs/redux/issues/2773">#&#8203;2773</a> by <a href="https://renovatebot.com/gh/aikoven">@&#8203;aikoven</a>)</li>
<li>Added prettier formatting (<a href="https://renovatebot.com/gh/reactjs/redux/issues/2676">#&#8203;2676</a> by <a href="https://renovatebot.com/gh/adityavohra7">@&#8203;adityavohra7</a>)</li>
<li>Add a sideEffects: false flag for Webpack 4 (<a href="https://renovatebot.com/gh/reactjs/redux/issues/2865">#&#8203;2865</a> by <a href="https://renovatebot.com/gh/timdorr">@&#8203;timdorr</a>)</li>
<li>Fix missed case in "observe" type check (<a href="https://renovatebot.com/gh/reactjs/redux/issues/2919">#&#8203;2919</a> by <a href="https://renovatebot.com/gh/zerobias">@&#8203;zerobias</a>)</li>
</ul>
<hr />
<p></details></p>
<hr />
<p>This PR has been generated by <a href="https://renovatebot.com">Renovate Bot</a>.</p>