### PR TITLE
Update dependency tslint to v5

### DIFF
--- a/Examples/xc.chat/webapp/package.json
+++ b/Examples/xc.chat/webapp/package.json
@@ -92,7 +92,7 @@
     "style-loader": "^0.23.0",
     "ts-jest": "^23.0.0",
     "ts-loader": "^5.0.0",
-    "tslint": "^4.1.0",
+    "tslint": "^5.0.0",
     "tslint-loader": "^3.3.0",
     "typescript": "^3.0.0",
     "webpack": "^4.0.0",

--- a/Examples/xc.chat/webapp/yarn.lock
+++ b/Examples/xc.chat/webapp/yarn.lock
@@ -404,12 +404,6 @@ amdefine@>=0.0.4:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/amdefine/-/amdefine-1.0.1.tgz#4a5282ac164729e93619bcfd3ad151f817ce91f5"
 
-ansi-align@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/ansi-align/-/ansi-align-2.0.0.tgz#c36aeccba563b89ceb556f3690f0b1d9e3547f7f"
-  dependencies:
-    string-width "^2.0.0"
-
 ansi-escapes@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-3.1.0.tgz#f73207bb81207d75fd6c83f125af26eea378ca30"
@@ -631,7 +625,7 @@ aws4@^1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.6.0.tgz#83ef5ca860b2b32e4a0deedee8c771b9db57471e"
 
-babel-code-frame@^6.20.0, babel-code-frame@^6.26.0:
+babel-code-frame@^6.22.0, babel-code-frame@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-code-frame/-/babel-code-frame-6.26.0.tgz#63fd43f7dc1e3bb7ce35947db8fe369a3f58c74b"
   dependencies:
@@ -951,18 +945,6 @@ boom@5.x.x:
   dependencies:
     hoek "4.x.x"
 
-boxen@^1.2.1:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/boxen/-/boxen-1.2.2.tgz#3f1d4032c30ffea9d4b02c322eaf2ea741dcbce5"
-  dependencies:
-    ansi-align "^2.0.0"
-    camelcase "^4.0.0"
-    chalk "^2.0.1"
-    cli-boxes "^1.0.0"
-    string-width "^2.0.0"
-    term-size "^1.2.0"
-    widest-line "^1.0.0"
-
 brace-expansion@^1.1.7:
   version "1.1.8"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.8.tgz#c07b211c7c952ec1f8efd51a77ef0d1d3990a292"
@@ -1125,7 +1107,7 @@ buffer@^4.3.0:
     ieee754 "^1.1.4"
     isarray "^1.0.0"
 
-builtin-modules@^1.0.0:
+builtin-modules@^1.0.0, builtin-modules@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-1.1.1.tgz#270f076c5a72c02f5b65a47df94c5fe3a278892f"
 
@@ -1199,7 +1181,7 @@ camelcase@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-3.0.0.tgz#32fc4b9fcdaf845fcdf7e73bb97cac2261f0ab0a"
 
-camelcase@^4.0.0, camelcase@^4.1.0:
+camelcase@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-4.1.0.tgz#d545635be1e33c542649c69173e5de6acfae34dd"
 
@@ -1353,10 +1335,6 @@ clean-webpack-plugin@^0.1.14:
   dependencies:
     rimraf "^2.6.1"
 
-cli-boxes@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/cli-boxes/-/cli-boxes-1.0.0.tgz#4fa917c3e59c94a004cd61f8ee509da651687143"
-
 cli-cursor@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-2.1.0.tgz#b35dac376479facc3e94747d41d0d0f5238ffcb5"
@@ -1455,7 +1433,7 @@ color-name@^1.1.1:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
 
-colors@^1.1.2, colors@~1.1.2:
+colors@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.1.2.tgz#168a4701756b6a7f51a12ce0c97bfa28c084ed63"
 
@@ -1468,6 +1446,10 @@ combined-stream@^1.0.5, combined-stream@~1.0.5:
 commander@2.11.x, commander@~2.11.0:
   version "2.11.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.11.0.tgz#157152fd1e7a6c8d98a5b715cf376df928004563"
+
+commander@^2.12.1:
+  version "2.17.1"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.17.1.tgz#bd77ab7de6de94205ceacc72f1716d29f20a77bf"
 
 commander@~2.13.0:
   version "2.13.0"
@@ -1536,17 +1518,6 @@ config-chain@^1.1.11:
   dependencies:
     ini "^1.3.4"
     proto-list "~1.2.1"
-
-configstore@^3.0.0:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/configstore/-/configstore-3.1.1.tgz#094ee662ab83fad9917678de114faaea8fcdca90"
-  dependencies:
-    dot-prop "^4.1.0"
-    graceful-fs "^4.1.2"
-    make-dir "^1.0.0"
-    unique-string "^1.0.0"
-    write-file-atomic "^2.0.0"
-    xdg-basedir "^3.0.0"
 
 connect-history-api-fallback@^1.3.0:
   version "1.5.0"
@@ -1632,7 +1603,7 @@ create-ecdh@^4.0.0:
     bn.js "^4.1.0"
     elliptic "^6.0.0"
 
-create-error-class@^3.0.0, create-error-class@^3.0.1:
+create-error-class@^3.0.1:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/create-error-class/-/create-error-class-3.0.2.tgz#06be7abef947a3f14a30fd610671d401bca8b7b6"
   dependencies:
@@ -1704,10 +1675,6 @@ crypto-browserify@^3.11.0:
     public-encrypt "^4.0.0"
     randombytes "^2.0.0"
     randomfill "^1.0.3"
-
-crypto-random-string@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/crypto-random-string/-/crypto-random-string-1.0.0.tgz#a230f64f568310e1498009940790ec99545bca7e"
 
 css-loader@^1.0.0:
   version "1.0.0"
@@ -2102,10 +2069,6 @@ detect-node@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/detect-node/-/detect-node-2.0.3.tgz#a2033c09cc8e158d37748fbde7507832bd6ce127"
 
-diff@^3.0.1:
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/diff/-/diff-3.4.0.tgz#b1d85507daf3964828de54b37d0d73ba67dda56c"
-
 diff@^3.2.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.5.0.tgz#800c0dd1e0a8bfbc95835c202ad220fe317e5a12"
@@ -2188,12 +2151,6 @@ domutils@1.5.1:
   dependencies:
     dom-serializer "0"
     domelementtype "1"
-
-dot-prop@^4.1.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/dot-prop/-/dot-prop-4.2.0.tgz#1f19e0c2e1aa0e32797c49799f2837ac6af69c57"
-  dependencies:
-    is-obj "^1.0.0"
 
 download@^4.0.0, download@^4.1.2:
   version "4.4.3"
@@ -2949,12 +2906,6 @@ find-versions@^1.0.0:
     meow "^3.5.0"
     semver-regex "^1.0.0"
 
-findup-sync@~0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/findup-sync/-/findup-sync-0.3.0.tgz#37930aa5d816b777c03445e1966cc6790a4c0b16"
-  dependencies:
-    glob "~5.0.0"
-
 first-chunk-stream@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz#59bfb50cd905f60d7c394cd3d9acaab4e6ad934e"
@@ -3179,7 +3130,7 @@ glob-stream@^5.3.2:
     to-absolute-glob "^0.1.1"
     unique-stream "^2.0.2"
 
-glob@^5.0.3, glob@~5.0.0:
+glob@^5.0.3:
   version "5.0.15"
   resolved "https://registry.yarnpkg.com/glob/-/glob-5.0.15.tgz#1bc936b9e02f4a603fcc222ecf7633d30b8b93b1"
   dependencies:
@@ -3199,12 +3150,6 @@ glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.1.1, glob@^7.1.2, glob@~7.1.1:
     minimatch "^3.0.4"
     once "^1.3.0"
     path-is-absolute "^1.0.0"
-
-global-dirs@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/global-dirs/-/global-dirs-0.1.0.tgz#10d34039e0df04272e262cf24224f7209434df4f"
-  dependencies:
-    ini "^1.3.4"
 
 global-modules-path@^2.1.0:
   version "2.3.0"
@@ -3256,22 +3201,6 @@ got@^5.0.0:
     readable-stream "^2.0.5"
     timed-out "^3.0.0"
     unzip-response "^1.0.2"
-    url-parse-lax "^1.0.0"
-
-got@^6.7.1:
-  version "6.7.1"
-  resolved "https://registry.yarnpkg.com/got/-/got-6.7.1.tgz#240cd05785a9a18e561dc1b44b41c763ef1e8db0"
-  dependencies:
-    create-error-class "^3.0.0"
-    duplexer3 "^0.1.4"
-    get-stream "^3.0.0"
-    is-redirect "^1.0.0"
-    is-retry-allowed "^1.0.0"
-    is-stream "^1.0.0"
-    lowercase-keys "^1.0.0"
-    safe-buffer "^5.0.1"
-    timed-out "^4.0.0"
-    unzip-response "^2.0.1"
     url-parse-lax "^1.0.0"
 
 got@^7.0.0:
@@ -3781,10 +3710,6 @@ imagemin@^5.3.1:
     pify "^2.3.0"
     replace-ext "^1.0.0"
 
-import-lazy@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/import-lazy/-/import-lazy-2.1.0.tgz#05698e3d45c88e8d7e9d92cb0584e77f096f3e43"
-
 import-local@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/import-local/-/import-local-1.0.0.tgz#5e4ffdc03f4fe6c009c6729beb29631c2f8227bc"
@@ -4134,13 +4059,6 @@ is-hexadecimal@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-hexadecimal/-/is-hexadecimal-1.0.1.tgz#6e084bbc92061fbb0971ec58b6ce6d404e24da69"
 
-is-installed-globally@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/is-installed-globally/-/is-installed-globally-0.1.0.tgz#0dfd98f5a9111716dd535dda6492f67bf3d25a80"
-  dependencies:
-    global-dirs "^0.1.0"
-    is-path-inside "^1.0.0"
-
 is-jpg@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-jpg/-/is-jpg-1.0.0.tgz#2959c17e73430db38264da75b90dd54f2d86da1c"
@@ -4152,10 +4070,6 @@ is-natural-number@^2.0.0:
 is-natural-number@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/is-natural-number/-/is-natural-number-4.0.1.tgz#ab9d76e1db4ced51e35de0c72ebecf09f734cde8"
-
-is-npm@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/is-npm/-/is-npm-1.0.0.tgz#f2fb63a65e4905b406c86072765a1a4dc793b9f4"
 
 is-number@^2.1.0:
   version "2.1.0"
@@ -4832,12 +4746,6 @@ kind-of@^6.0.0, kind-of@^6.0.2:
 kleur@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/kleur/-/kleur-2.0.1.tgz#7cc64b0d188d0dcbc98bdcdfdda2cc10619ddce8"
-
-latest-version@^3.0.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/latest-version/-/latest-version-3.1.0.tgz#a205383fea322b33b5ae3b18abee0dc2f356ee15"
-  dependencies:
-    package-json "^4.0.0"
 
 lazy-cache@^1.0.3:
   version "1.0.4"
@@ -5816,7 +5724,7 @@ opn@^5.1.0:
   dependencies:
     is-wsl "^1.1.0"
 
-optimist@^0.6.1, optimist@~0.6.0:
+optimist@^0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/optimist/-/optimist-0.6.1.tgz#da3ea74686fa21a19a111c326e90eb15a0196686"
   dependencies:
@@ -5955,15 +5863,6 @@ p-timeout@^1.1.1:
 p-try@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-2.0.0.tgz#85080bb87c64688fa47996fe8f7dfbe8211760b1"
-
-package-json@^4.0.0:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/package-json/-/package-json-4.0.1.tgz#8869a0401253661c4c4ca3da6c2121ed555f5eed"
-  dependencies:
-    got "^6.7.1"
-    registry-auth-token "^3.0.1"
-    registry-url "^3.0.3"
-    semver "^5.1.0"
 
 pako@^1.0.3:
   version "1.0.6"
@@ -6423,7 +6322,7 @@ raw-body@2.3.2:
     iconv-lite "0.4.19"
     unpipe "1.0.0"
 
-rc@^1.0.1, rc@^1.1.2, rc@^1.1.6:
+rc@^1.1.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.2.tgz#d8ce9cb57e8d64d9c7badd9876c7c34cbe3c7077"
   dependencies:
@@ -6697,19 +6596,6 @@ regexpu-core@^1.0.0:
     regjsgen "^0.2.0"
     regjsparser "^0.1.4"
 
-registry-auth-token@^3.0.1:
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/registry-auth-token/-/registry-auth-token-3.3.1.tgz#fb0d3289ee0d9ada2cbb52af5dfe66cb070d3006"
-  dependencies:
-    rc "^1.1.6"
-    safe-buffer "^5.0.1"
-
-registry-url@^3.0.3:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/registry-url/-/registry-url-3.1.0.tgz#3d4ef870f73dde1d77f0cf9a381432444e174942"
-  dependencies:
-    rc "^1.0.1"
-
 regjsgen@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/regjsgen/-/regjsgen-0.2.0.tgz#6c016adeac554f75823fe37ac05b92d5a4edb1f7"
@@ -6884,9 +6770,9 @@ resolve@1.1.7:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
 
-resolve@^1.1.7:
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.5.0.tgz#1f09acce796c9a762579f31b2c1cc4c3cddf9f36"
+resolve@^1.3.2:
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.8.1.tgz#82f1ec19a423ac1fbd080b0bab06ba36e84a7a26"
   dependencies:
     path-parse "^1.0.5"
 
@@ -7060,12 +6946,6 @@ selfsigned@^1.9.1:
   dependencies:
     node-forge "0.6.33"
 
-semver-diff@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/semver-diff/-/semver-diff-2.1.0.tgz#4bbb8437c8d37e4b0cf1a68fd726ec6d645d6d36"
-  dependencies:
-    semver "^5.0.3"
-
 semver-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/semver-regex/-/semver-regex-1.0.0.tgz#92a4969065f9c70c694753d55248fc68f8f652c9"
@@ -7076,7 +6956,7 @@ semver-truncate@^1.0.0:
   dependencies:
     semver "^5.3.0"
 
-"semver@2 || 3 || 4 || 5", semver@^5.0.1, semver@^5.0.3, semver@^5.1.0, semver@^5.3.0:
+"semver@2 || 3 || 4 || 5", semver@^5.0.1, semver@^5.3.0:
   version "5.4.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.4.1.tgz#e059c09d8571f0540823733433505d3a2f00b18e"
 
@@ -7760,12 +7640,6 @@ tempfile@^2.0.0:
     temp-dir "^1.0.0"
     uuid "^3.0.1"
 
-term-size@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/term-size/-/term-size-1.2.0.tgz#458b83887f288fc56d6fffbfad262e26638efa69"
-  dependencies:
-    execa "^0.7.0"
-
 test-exclude@^4.2.1:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/test-exclude/-/test-exclude-4.2.1.tgz#dfa222f03480bca69207ca728b37d74b45f724fa"
@@ -7944,7 +7818,7 @@ ts-loader@^5.0.0:
     micromatch "^3.1.4"
     semver "^5.0.1"
 
-tslib@^1.9.0:
+tslib@^1.8.0, tslib@^1.8.1, tslib@^1.9.0:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.3.tgz#d7e4dd79245d85428c4d7e4822a79917954ca286"
 
@@ -7958,23 +7832,28 @@ tslint-loader@^3.3.0:
     rimraf "^2.4.4"
     semver "^5.3.0"
 
-tslint@^4.1.0:
-  version "4.5.1"
-  resolved "https://registry.yarnpkg.com/tslint/-/tslint-4.5.1.tgz#05356871bef23a434906734006fc188336ba824b"
+tslint@^5.0.0:
+  version "5.11.0"
+  resolved "https://registry.yarnpkg.com/tslint/-/tslint-5.11.0.tgz#98f30c02eae3cde7006201e4c33cb08b48581eed"
   dependencies:
-    babel-code-frame "^6.20.0"
-    colors "^1.1.2"
-    diff "^3.0.1"
-    findup-sync "~0.3.0"
+    babel-code-frame "^6.22.0"
+    builtin-modules "^1.1.1"
+    chalk "^2.3.0"
+    commander "^2.12.1"
+    diff "^3.2.0"
     glob "^7.1.1"
-    optimist "~0.6.0"
-    resolve "^1.1.7"
-    tsutils "^1.1.0"
-    update-notifier "^2.0.0"
+    js-yaml "^3.7.0"
+    minimatch "^3.0.4"
+    resolve "^1.3.2"
+    semver "^5.3.0"
+    tslib "^1.8.0"
+    tsutils "^2.27.2"
 
-tsutils@^1.1.0:
-  version "1.9.1"
-  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-1.9.1.tgz#b9f9ab44e55af9681831d5f28d0aeeaf5c750cb0"
+tsutils@^2.27.2:
+  version "2.29.0"
+  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-2.29.0.tgz#32b488501467acbedd4b85498673a0812aca0b99"
+  dependencies:
+    tslib "^1.8.1"
 
 tty-browserify@0.0.0:
   version "0.0.0"
@@ -8126,12 +8005,6 @@ unique-stream@^2.0.2:
     json-stable-stringify "^1.0.0"
     through2-filter "^2.0.0"
 
-unique-string@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/unique-string/-/unique-string-1.0.0.tgz#9e1057cca851abb93398f8b33ae187b99caec11a"
-  dependencies:
-    crypto-random-string "^1.0.0"
-
 unist-util-remove-position@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/unist-util-remove-position/-/unist-util-remove-position-1.1.1.tgz#5a85c1555fc1ba0c101b86707d15e50fa4c871bb"
@@ -8169,27 +8042,9 @@ unzip-response@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/unzip-response/-/unzip-response-1.0.2.tgz#b984f0877fc0a89c2c773cc1ef7b5b232b5b06fe"
 
-unzip-response@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/unzip-response/-/unzip-response-2.0.1.tgz#d2f0f737d16b0615e72a6935ed04214572d56f97"
-
 upath@^1.0.5:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/upath/-/upath-1.1.0.tgz#35256597e46a581db4793d0ce47fa9aebfc9fabd"
-
-update-notifier@^2.0.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/update-notifier/-/update-notifier-2.3.0.tgz#4e8827a6bb915140ab093559d7014e3ebb837451"
-  dependencies:
-    boxen "^1.2.1"
-    chalk "^2.0.1"
-    configstore "^3.0.0"
-    import-lazy "^2.1.0"
-    is-installed-globally "^0.1.0"
-    is-npm "^1.0.0"
-    latest-version "^3.0.0"
-    semver-diff "^2.0.0"
-    xdg-basedir "^3.0.0"
 
 upper-case@^1.1.1:
   version "1.1.3"
@@ -8632,12 +8487,6 @@ wide-align@^1.1.0:
   dependencies:
     string-width "^1.0.2"
 
-widest-line@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/widest-line/-/widest-line-1.0.0.tgz#0c09c85c2a94683d0d7eaf8ee097d564bf0e105c"
-  dependencies:
-    string-width "^1.0.1"
-
 window-size@0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/window-size/-/window-size-0.1.0.tgz#5438cd2ea93b202efa3a19fe8887aee7c94f9c9d"
@@ -8677,7 +8526,7 @@ wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
 
-write-file-atomic@^2.0.0, write-file-atomic@^2.1.0:
+write-file-atomic@^2.1.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/write-file-atomic/-/write-file-atomic-2.3.0.tgz#1ff61575c2e2a4e8e510d6fa4e243cce183999ab"
   dependencies:
@@ -8698,10 +8547,6 @@ x-is-function@^1.0.4:
 x-is-string@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/x-is-string/-/x-is-string-0.1.0.tgz#474b50865af3a49a9c4657f05acd145458f77d82"
-
-xdg-basedir@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/xdg-basedir/-/xdg-basedir-3.0.0.tgz#496b2cc109eca8dbacfe2dc72b603c17c5870ad4"
 
 xml-char-classes@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
<p>This Pull Request updates dependency <a href="https://renovatebot.com/gh/palantir/tslint">tslint</a> from <code>^4.1.0</code> to <code>^5.0.0</code></p>
<p><details><br />
<summary>Release Notes</summary></p>
<h3 id="v5110httpsgithubcompalantirtslintblobmasterchangelogmdv5110"><a href="https://renovatebot.com/gh/palantir/tslint/blob/master/CHANGELOG.md#v5110"><code>v5.11.0</code></a></h3>
<p><a href="https://renovatebot.com/gh/palantir/tslint/compare/5.10.0…5.11.0">Compare Source</a></p>
<hr />
<h3 id="v5100httpsgithubcompalantirtslintblobmasterchangelogmdv5100"><a href="https://renovatebot.com/gh/palantir/tslint/blob/master/CHANGELOG.md#v5100"><code>v5.10.0</code></a></h3>
<p><a href="https://renovatebot.com/gh/palantir/tslint/compare/5.9.1…5.10.0">Compare Source</a></p>
<hr />
<h3 id="v591httpsgithubcompalantirtslintblobmasterchangelogmdv591"><a href="https://renovatebot.com/gh/palantir/tslint/blob/master/CHANGELOG.md#v591"><code>v5.9.1</code></a></h3>
<p><a href="https://renovatebot.com/gh/palantir/tslint/compare/5.9.0…5.9.1">Compare Source</a></p>
<hr />
<h3 id="v590httpsgithubcompalantirtslintblobmasterchangelogmdv590"><a href="https://renovatebot.com/gh/palantir/tslint/blob/master/CHANGELOG.md#v590"><code>v5.9.0</code></a></h3>
<p><a href="https://renovatebot.com/gh/palantir/tslint/compare/5.8.0…5.9.0">Compare Source</a></p>
<hr />
<h3 id="v580httpsgithubcompalantirtslintblobmasterchangelogmdv580"><a href="https://renovatebot.com/gh/palantir/tslint/blob/master/CHANGELOG.md#v580"><code>v5.8.0</code></a></h3>
<p><a href="https://renovatebot.com/gh/palantir/tslint/compare/5.7.0…5.8.0">Compare Source</a></p>
<hr />
<h3 id="v570httpsgithubcompalantirtslintblobmasterchangelogmdv570"><a href="https://renovatebot.com/gh/palantir/tslint/blob/master/CHANGELOG.md#v570"><code>v5.7.0</code></a></h3>
<p><a href="https://renovatebot.com/gh/palantir/tslint/compare/5.6.0…5.7.0">Compare Source</a></p>
<hr />
<h3 id="v560httpsgithubcompalantirtslintblobmasterchangelogmdv560"><a href="https://renovatebot.com/gh/palantir/tslint/blob/master/CHANGELOG.md#v560"><code>v5.6.0</code></a></h3>
<p><a href="https://renovatebot.com/gh/palantir/tslint/compare/5.5.0…5.6.0">Compare Source</a></p>
<hr />
<h3 id="v550httpsgithubcompalantirtslintblobmasterchangelogmdv550"><a href="https://renovatebot.com/gh/palantir/tslint/blob/master/CHANGELOG.md#v550"><code>v5.5.0</code></a></h3>
<p><a href="https://renovatebot.com/gh/palantir/tslint/compare/5.4.3…5.5.0">Compare Source</a><br />
<strong>Editor's note</strong>: This release features an important bugfix for overlapping fixes when using <code>--project</code> and <code>--fix</code> (<a href="https://renovatebot.com/gh/palantir/tslint/issues/2864">#&#8203;2864</a>).</p>
<hr />
<h3 id="v543httpsgithubcompalantirtslintblobmasterchangelogmdv543"><a href="https://renovatebot.com/gh/palantir/tslint/blob/master/CHANGELOG.md#v543"><code>v5.4.3</code></a></h3>
<p><a href="https://renovatebot.com/gh/palantir/tslint/compare/5.4.2…5.4.3">Compare Source</a></p>
<hr />
<h3 id="v542httpsgithubcompalantirtslintblobmasterchangelogmdv542"><a href="https://renovatebot.com/gh/palantir/tslint/blob/master/CHANGELOG.md#v542"><code>v5.4.2</code></a></h3>
<p><a href="https://renovatebot.com/gh/palantir/tslint/compare/5.4.1…5.4.2">Compare Source</a></p>
<hr />
<h3 id="v541httpsgithubcompalantirtslintblobmasterchangelogmdv541"><a href="https://renovatebot.com/gh/palantir/tslint/blob/master/CHANGELOG.md#v541"><code>v5.4.1</code></a></h3>
<p><a href="https://renovatebot.com/gh/palantir/tslint/compare/5.4.0…5.4.1">Compare Source</a></p>
<hr />
<h3 id="v540httpsgithubcompalantirtslintblobmasterchangelogmdv540"><a href="https://renovatebot.com/gh/palantir/tslint/blob/master/CHANGELOG.md#v540"><code>v5.4.0</code></a></h3>
<p><a href="https://renovatebot.com/gh/palantir/tslint/compare/5.3.2…5.4.0">Compare Source</a></p>
<hr />
<h3 id="v532httpsgithubcompalantirtslintblobmasterchangelogmdv532"><a href="https://renovatebot.com/gh/palantir/tslint/blob/master/CHANGELOG.md#v532"><code>v5.3.2</code></a></h3>
<p><a href="https://renovatebot.com/gh/palantir/tslint/compare/5.3.0…5.3.2">Compare Source</a></p>
<ul>
<li>[bugfix] Fixes <code>not a directory</code> error (<a href="https://renovatebot.com/gh/palantir/tslint/issues/2813">#&#8203;2813</a>)</li>
</ul>
<hr />
<h3 id="v530httpsgithubcompalantirtslintblobmasterchangelogmdv530"><a href="https://renovatebot.com/gh/palantir/tslint/blob/master/CHANGELOG.md#v530"><code>v5.3.0</code></a></h3>
<p><a href="https://renovatebot.com/gh/palantir/tslint/compare/5.2.0…5.3.0">Compare Source</a></p>
<hr />
<h3 id="v520httpsgithubcompalantirtslintblobmasterchangelogmdv520"><a href="https://renovatebot.com/gh/palantir/tslint/blob/master/CHANGELOG.md#v520"><code>v5.2.0</code></a></h3>
<p><a href="https://renovatebot.com/gh/palantir/tslint/compare/5.1.0…5.2.0">Compare Source</a></p>
<ul>
<li>[rule-change]<a href="https://palantir.github.io/tslint/rules/no-console/"><code>no-console</code></a> bans all console methods when no methods are specified (<a href="https://renovatebot.com/gh/palantir/tslint/issues/2610">#&#8203;2610</a>)</li>
<li>[new-rule]<a href="https://palantir.github.io/tslint/rules/no-object-literal-type-assertion/"><code>no-object-literal-type-assertion</code></a> (<a href="https://renovatebot.com/gh/palantir/tslint/issues/2580">#&#8203;2580</a>)</li>
<li>[new-rule]<a href="https://palantir.github.io/tslint/rules/no-irregular-whitespace/"><code>no-irregular-whitespace</code></a> (<a href="https://renovatebot.com/gh/palantir/tslint/issues/2487">#&#8203;2487</a>)</li>
<li>[new-rule]<a href="https://palantir.github.io/tslint/rules/prefer-switch/"><code>prefer-switch</code></a> (<a href="https://renovatebot.com/gh/palantir/tslint/issues/2331">#&#8203;2331</a>)</li>
<li>[new-rule]<a href="https://palantir.github.io/tslint/rules/number-literal-format/"><code>number-literal-format</code></a> (<a href="https://renovatebot.com/gh/palantir/tslint/issues/2526">#&#8203;2526</a>)</li>
<li>[new-rule]<a href="https://palantir.github.io/tslint/rules/deprecation/"><code>deprecation</code></a> (<a href="https://renovatebot.com/gh/palantir/tslint/issues/2395">#&#8203;2395</a>)</li>
<li>[new-rule]<a href="https://palantir.github.io/tslint/rules/no-unnecessary-type-assertion/"><code>no-unnecessary-type-assertion</code></a> (<a href="https://renovatebot.com/gh/palantir/tslint/issues/2519">#&#8203;2519</a>)</li>
<li>[new-fixer]<a href="https://palantir.github.io/tslint/rules/interface-over-type-literal/"><code>interface-over-type-literal</code></a> (<a href="https://renovatebot.com/gh/palantir/tslint/issues/2617">#&#8203;2617</a>)</li>
<li>[new-fixer]<a href="https://palantir.github.io/tslint/rules/callable-types/"><code>callable-types</code></a> (<a href="https://renovatebot.com/gh/palantir/tslint/issues/2552">#&#8203;2552</a>)</li>
<li>[new-fixer]<a href="https://palantir.github.io/tslint/rules/no-string-literal/"><code>no-string-literal</code></a> (<a href="https://renovatebot.com/gh/palantir/tslint/issues/2495">#&#8203;2495</a>)</li>
<li>[new-fixer]<a href="https://palantir.github.io/tslint/rules/no-internal-module/"><code>no-internal-module</code></a> (<a href="https://renovatebot.com/gh/palantir/tslint/issues/2517">#&#8203;2517</a>)</li>
<li>[new-rule-option]<a href="https://palantir.github.io/tslint/rules/align/"><code>align</code></a> rule added <code>members</code> option, which checks alignment of methods and properties of classes, objects, interfaces, type literals and object destructuring (<a href="https://renovatebot.com/gh/palantir/tslint/issues/2387">#&#8203;2387</a>)</li>
<li>[new-rule-option]<a href="https://palantir.github.io/tslint/rules/align/"><code>align</code></a> rule added <code>elements</code> option, which checks alignment of elements in array literals, array destructuring and tuple types (<a href="https://renovatebot.com/gh/palantir/tslint/issues/2387">#&#8203;2387</a>)</li>
<li>[new-rule-option]<a href="https://palantir.github.io/tslint/rules/trailing-comma/"><code>trailing-comma</code></a> adds more granular options to specify trailing commas for arrays, objects, functions, type literals, imports, and exports (<a href="https://renovatebot.com/gh/palantir/tslint/issues/2538">#&#8203;2538</a>)</li>
<li>[api] Deprecate <code>ScopeAwareRuleWalker</code> and <code>BlockScopeAwareRuleWalker</code>. (<a href="https://renovatebot.com/gh/palantir/tslint/issues/2561">#&#8203;2561</a>)</li>
<li>[develop] added support for <a href="https://palantir.github.io/tslint/develop/testing-rules/">error templates in rule tests</a> (<a href="https://renovatebot.com/gh/palantir/tslint/issues/2481">#&#8203;2481</a>)</li>
<li>[bugfix] Fixes "Severity for rule not found" error (<a href="https://renovatebot.com/gh/palantir/tslint/issues/2516">#&#8203;2516</a>)</li>
<li>[bugfix]<a href="https://palantir.github.io/tslint/rules/no-unused-expression/"><code>no-unused-expression</code></a>: allow <code>void(0)</code> in addition to <code>void 0</code> and <code>void</code> in expression and statement position (<a href="https://renovatebot.com/gh/palantir/tslint/issues/2645">#&#8203;2645</a>)</li>
<li>[bugfix]<a href="https://palantir.github.io/tslint/rules/align/"><code>align</code></a>: fix false positive for files with BOM (<a href="https://renovatebot.com/gh/palantir/tslint/issues/2642">#&#8203;2642</a>)</li>
<li>[bugfix]<a href="https://palantir.github.io/tslint/rules/return-undefined/"><code>return-undefined</code></a>: Handle contextual types with ambiguous signatures; allow <code>any</code>; and handle async functions. (<a href="https://renovatebot.com/gh/palantir/tslint/issues/2576">#&#8203;2576</a>)</li>
<li>[bugfix]<a href="https://palantir.github.io/tslint/rules/semicolon/"><code>semicolon</code></a>: don't mark semicolon as unnecessary when the next statement is on the same line (<a href="https://renovatebot.com/gh/palantir/tslint/issues/2591">#&#8203;2591</a>)</li>
<li>[bugfix]<a href="https://palantir.github.io/tslint/rules/no-internal-module/"><code>no-internal-module</code></a>: no more false positives for global augmentation (<a href="https://renovatebot.com/gh/palantir/tslint/issues/2517">#&#8203;2517</a>)</li>
<li>[bugfix]<a href="https://palantir.github.io/tslint/rules/no-unnecessary-qualifier/"><code>no-unnecessary-qualifier</code></a>: no longer breaks when walking a function that references <code>arguments</code> (<a href="https://renovatebot.com/gh/palantir/tslint/issues/2555">#&#8203;2555</a>)</li>
<li>[bugfix]<a href="https://palantir.github.io/tslint/rules/prefer-const/"><code>prefer-const</code></a> no longer shows warnings on ambient declarations (<a href="https://renovatebot.com/gh/palantir/tslint/issues/2391">#&#8203;2391</a>)</li>
<li>[bugfix]<a href="https://palantir.github.io/tslint/rules/callable-types/"><code>callable-types</code></a>: suggest correct fix for interfaces with type arguments (<a href="https://renovatebot.com/gh/palantir/tslint/issues/2552">#&#8203;2552</a>)</li>
<li>[bugfix]<a href="https://palantir.github.io/tslint/rules/quotemark/"><code>quotemark</code></a>: fix regression with jsx attributes (<a href="https://renovatebot.com/gh/palantir/tslint/issues/2605">#&#8203;2605</a>)</li>
<li>[bugfix]<a href="https://palantir.github.io/tslint/rules/adjacent-overload-signatures/"><code>adjacent-overload-signatures</code></a> handles functions ending in semicolon (<a href="https://renovatebot.com/gh/palantir/tslint/issues/2412">#&#8203;2412</a>)</li>
<li>[bugfix]<a href="https://palantir.github.io/tslint/rules/object-literal-key-quotes/"><code>object-literal-key-quotes</code></a>: correctly stringify numbers when fixing (<a href="https://renovatebot.com/gh/palantir/tslint/issues/2515">#&#8203;2515</a>)</li>
<li>[bugfix]<a href="https://palantir.github.io/tslint/rules/object-literal-key-quotes/"><code>object-literal-key-quotes</code></a>: does no longer require quotes for property names containing digits (<a href="https://renovatebot.com/gh/palantir/tslint/issues/2515">#&#8203;2515</a>)</li>
<li>[enhancement] Failures in extended config files now indicate which file (<a href="https://renovatebot.com/gh/palantir/tslint/issues/2588">#&#8203;2588</a>)</li>
<li>[enhancement]<a href="https://palantir.github.io/tslint/rules/align/"><code>align</code></a>: Don't report 'statements are not aligned' for empty statements (<a href="https://renovatebot.com/gh/palantir/tslint/issues/2653">#&#8203;2653</a>)</li>
<li>[enhancement]<a href="https://palantir.github.io/tslint/rules/class-name/"><code>class-name</code></a> now also checks class expressions (<a href="https://renovatebot.com/gh/palantir/tslint/issues/2553">#&#8203;2553</a>)</li>
<li>[enhancement] <code>optionExamples</code>: Allow to use an options array directly instead of a string representation. (<a href="https://renovatebot.com/gh/palantir/tslint/issues/2527">#&#8203;2527</a>)</li>
<li>[enhancement] <code>rulesDirectory</code> can now be resolved with Nodes resolve logic, if the directory contains an <code>index.js</code> (<a href="https://renovatebot.com/gh/palantir/tslint/issues/2163">#&#8203;2163</a>) (<a href="https://renovatebot.com/gh/palantir/tslint/issues/2358">#&#8203;2358</a>)</li>
<li>[enhancement]<a href="https://palantir.github.io/tslint/rules/no-unused-expression/"><code>no-unused-expression</code></a>: narrow error location for comma separated expressions and conditional expressions (<a href="https://renovatebot.com/gh/palantir/tslint/issues/2645">#&#8203;2645</a>)</li>
<li>[enhancement]<a href="https://palantir.github.io/tslint/rules/no-string-literal/"><code>no-string-literal</code></a> now handles escaped strings (<a href="https://renovatebot.com/gh/palantir/tslint/issues/2495">#&#8203;2495</a>)</li>
<li>[enhancement]<a href="https://palantir.github.io/tslint/rules/no-unnecessary-callback-wrapper/"><code>no-unnecessary-callback-wrapper</code></a>: Allow <code>x =&gt; x(x)</code> (<a href="https://renovatebot.com/gh/palantir/tslint/issues/2524">#&#8203;2524</a>)</li>
<li>[enhancement]<a href="https://palantir.github.io/tslint/rules/no-var-keyword/"><code>no-var-keyword</code></a>: Allow global var declarations (<a href="https://renovatebot.com/gh/palantir/tslint/issues/2513">#&#8203;2513</a>)</li>
</ul>
<p>Thanks to our contributors!</p>
<ul>
<li>Andy Hanson</li>
<li>Alex Eagle</li>
<li>Donald Pipowitch</li>
<li>Klaus Meinhardt</li>
<li>Gord P</li>
<li>Andy</li>
<li>Quentin</li>
<li>Mitchell Wills</li>
<li>Vito</li>
<li>CSchulz</li>
<li>Josh Goldberg</li>
<li>Brian Olore</li>
<li>Manuel Lopez</li>
<li>James Clark</li>
</ul>
<hr />
<h3 id="v510httpsgithubcompalantirtslintblobmasterchangelogmdv510"><a href="https://renovatebot.com/gh/palantir/tslint/blob/master/CHANGELOG.md#v510"><code>v5.1.0</code></a></h3>
<p><a href="https://renovatebot.com/gh/palantir/tslint/compare/5.0.0…5.1.0">Compare Source</a></p>
<ul>
<li>[new-rule] <code>no-invalid-template-strings</code> (<a href="https://renovatebot.com/gh/palantir/tslint/issues/2332">#&#8203;2332</a>)</li>
<li>[new-rule] <code>no-sparse-arrays</code> (<a href="https://renovatebot.com/gh/palantir/tslint/issues/2407">#&#8203;2407</a>)</li>
<li>[new-rule-option] <code>no-void-expression</code>: adds <code>ignore-arrow-function-shorthand</code> (<a href="https://renovatebot.com/gh/palantir/tslint/issues/2445">#&#8203;2445</a>)</li>
<li>[api] <code>tslint:all</code> configuration (<a href="https://renovatebot.com/gh/palantir/tslint/issues/2417">#&#8203;2417</a>)</li>
<li>[bugfix] In tslint:recommended move <code>no-reference-import</code> from <code>jsRules</code> to <code>rules</code> (<a href="https://renovatebot.com/gh/palantir/tslint/issues/2441">#&#8203;2441</a>)</li>
<li>[bugfix] <code>no-unnecessary-callback-wrapper</code>: only check if callback is identifier, allow all other expressions (<a href="https://renovatebot.com/gh/palantir/tslint/issues/2510">#&#8203;2510</a>)</li>
<li>[bugfix] <code>member-access</code>: Skip index signature, it can not have an access modifier (<a href="https://renovatebot.com/gh/palantir/tslint/issues/2437">#&#8203;2437</a>)</li>
<li>[bugfix] <code>restrict-plus-operands</code> fixes regression where every assignment and comparison was checked (<a href="https://renovatebot.com/gh/palantir/tslint/issues/2454">#&#8203;2454</a>)</li>
<li>[bugfix] <code>no-unnecessary-callback-wrapper</code>: allow async wrapper function (<a href="https://renovatebot.com/gh/palantir/tslint/issues/2510">#&#8203;2510</a>)</li>
<li>[bugfix] <code>prefer-for-of</code>: No error if <code>delete</code> is used (<a href="https://renovatebot.com/gh/palantir/tslint/issues/2458">#&#8203;2458</a>)</li>
<li>[bugfix] <code>radix</code>: don't warn for missing radix on method calls (<a href="https://renovatebot.com/gh/palantir/tslint/issues/2352">#&#8203;2352</a>)</li>
<li>[bugfix] <code>no-use-before-declare</code>: Handle symbol with empty declarations list. (<a href="https://renovatebot.com/gh/palantir/tslint/issues/2436">#&#8203;2436</a>)</li>
<li>[bugfix] <code>strict-type-predicates</code>: Check for construct signatures in <code>isFunction</code>. (<a href="https://renovatebot.com/gh/palantir/tslint/issues/2479">#&#8203;2479</a>)</li>
<li>[enhancement] <code>strict-boolean-expressions</code>: When <code>--strictNullChecks</code> is turned off, <code>allow-null-union</code> and <code>allow-undefined-union</code> turn off "always truthy" errors. (<a href="https://renovatebot.com/gh/palantir/tslint/issues/2373">#&#8203;2373</a>)</li>
<li>[enhancement] <code>radix</code>: added check for global.parseInt and window.parseInt (<a href="https://renovatebot.com/gh/palantir/tslint/issues/2352">#&#8203;2352</a>)</li>
<li>[enhancement] <code>arrow-return-shorthand</code>: Improve failure message when return expression is an object literal (<a href="https://renovatebot.com/gh/palantir/tslint/issues/2466">#&#8203;2466</a>)</li>
</ul>
<p>Thanks to our contributors!</p>
<ul>
<li>Andy Hanson</li>
<li>bumbleblym</li>
<li>Klaus Meinhardt</li>
<li>Jonas Kello</li>
<li>Minko Gechev</li>
<li>Donald Pipowitch</li>
</ul>
<hr />
<h3 id="v500httpsgithubcompalantirtslintblobmasterchangelogmdv500"><a href="https://renovatebot.com/gh/palantir/tslint/blob/master/CHANGELOG.md#v500"><code>v5.0.0</code></a></h3>
<p><a href="https://renovatebot.com/gh/palantir/tslint/compare/4.5.1…5.0.0">Compare Source</a></p>
<hr />
<p></details></p>
<hr />
<p>This PR has been generated by <a href="https://renovatebot.com">Renovate Bot</a>.</p>