### PR TITLE
Update dependency webpack to v4

### DIFF
--- a/Examples/xc.chat/webapp/package.json
+++ b/Examples/xc.chat/webapp/package.json
@@ -95,7 +95,7 @@
     "tslint": "^4.1.0",
     "tslint-loader": "^3.3.0",
     "typescript": "^3.0.0",
-    "webpack": "^2.2.1",
+    "webpack": "^4.0.0",
     "webpack-cli": "^3.1.0",
     "webpack-dev-server": "^3.0.0"
   }

--- a/Examples/xc.chat/webapp/yarn.lock
+++ b/Examples/xc.chat/webapp/yarn.lock
@@ -180,6 +180,142 @@
   version "0.1.29"
   resolved "https://registry.yarnpkg.com/@types/xmldom/-/xmldom-0.1.29.tgz#c4428b0ca86d3b881475726fd94980b38a27c381"
 
+"@webassemblyjs/ast@1.5.13":
+  version "1.5.13"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/ast/-/ast-1.5.13.tgz#81155a570bd5803a30ec31436bc2c9c0ede38f25"
+  dependencies:
+    "@webassemblyjs/helper-module-context" "1.5.13"
+    "@webassemblyjs/helper-wasm-bytecode" "1.5.13"
+    "@webassemblyjs/wast-parser" "1.5.13"
+    debug "^3.1.0"
+    mamacro "^0.0.3"
+
+"@webassemblyjs/floating-point-hex-parser@1.5.13":
+  version "1.5.13"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.5.13.tgz#29ce0baa97411f70e8cce68ce9c0f9d819a4e298"
+
+"@webassemblyjs/helper-api-error@1.5.13":
+  version "1.5.13"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-api-error/-/helper-api-error-1.5.13.tgz#e49b051d67ee19a56e29b9aa8bd949b5b4442a59"
+
+"@webassemblyjs/helper-buffer@1.5.13":
+  version "1.5.13"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-buffer/-/helper-buffer-1.5.13.tgz#873bb0a1b46449231137c1262ddfd05695195a1e"
+  dependencies:
+    debug "^3.1.0"
+
+"@webassemblyjs/helper-code-frame@1.5.13":
+  version "1.5.13"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-code-frame/-/helper-code-frame-1.5.13.tgz#1bd2181b6a0be14e004f0fe9f5a660d265362b58"
+  dependencies:
+    "@webassemblyjs/wast-printer" "1.5.13"
+
+"@webassemblyjs/helper-fsm@1.5.13":
+  version "1.5.13"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-fsm/-/helper-fsm-1.5.13.tgz#cdf3d9d33005d543a5c5e5adaabf679ffa8db924"
+
+"@webassemblyjs/helper-module-context@1.5.13":
+  version "1.5.13"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-module-context/-/helper-module-context-1.5.13.tgz#dc29ddfb51ed657655286f94a5d72d8a489147c5"
+  dependencies:
+    debug "^3.1.0"
+    mamacro "^0.0.3"
+
+"@webassemblyjs/helper-wasm-bytecode@1.5.13":
+  version "1.5.13"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.5.13.tgz#03245817f0a762382e61733146f5773def15a747"
+
+"@webassemblyjs/helper-wasm-section@1.5.13":
+  version "1.5.13"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.5.13.tgz#efc76f44a10d3073b584b43c38a179df173d5c7d"
+  dependencies:
+    "@webassemblyjs/ast" "1.5.13"
+    "@webassemblyjs/helper-buffer" "1.5.13"
+    "@webassemblyjs/helper-wasm-bytecode" "1.5.13"
+    "@webassemblyjs/wasm-gen" "1.5.13"
+    debug "^3.1.0"
+
+"@webassemblyjs/ieee754@1.5.13":
+  version "1.5.13"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/ieee754/-/ieee754-1.5.13.tgz#573e97c8c12e4eebb316ca5fde0203ddd90b0364"
+  dependencies:
+    ieee754 "^1.1.11"
+
+"@webassemblyjs/leb128@1.5.13":
+  version "1.5.13"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/leb128/-/leb128-1.5.13.tgz#ab52ebab9cec283c1c1897ac1da833a04a3f4cee"
+  dependencies:
+    long "4.0.0"
+
+"@webassemblyjs/utf8@1.5.13":
+  version "1.5.13"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/utf8/-/utf8-1.5.13.tgz#6b53d2cd861cf94fa99c1f12779dde692fbc2469"
+
+"@webassemblyjs/wasm-edit@1.5.13":
+  version "1.5.13"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-edit/-/wasm-edit-1.5.13.tgz#c9cef5664c245cf11b3b3a73110c9155831724a8"
+  dependencies:
+    "@webassemblyjs/ast" "1.5.13"
+    "@webassemblyjs/helper-buffer" "1.5.13"
+    "@webassemblyjs/helper-wasm-bytecode" "1.5.13"
+    "@webassemblyjs/helper-wasm-section" "1.5.13"
+    "@webassemblyjs/wasm-gen" "1.5.13"
+    "@webassemblyjs/wasm-opt" "1.5.13"
+    "@webassemblyjs/wasm-parser" "1.5.13"
+    "@webassemblyjs/wast-printer" "1.5.13"
+    debug "^3.1.0"
+
+"@webassemblyjs/wasm-gen@1.5.13":
+  version "1.5.13"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-gen/-/wasm-gen-1.5.13.tgz#8e6ea113c4b432fa66540189e79b16d7a140700e"
+  dependencies:
+    "@webassemblyjs/ast" "1.5.13"
+    "@webassemblyjs/helper-wasm-bytecode" "1.5.13"
+    "@webassemblyjs/ieee754" "1.5.13"
+    "@webassemblyjs/leb128" "1.5.13"
+    "@webassemblyjs/utf8" "1.5.13"
+
+"@webassemblyjs/wasm-opt@1.5.13":
+  version "1.5.13"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-opt/-/wasm-opt-1.5.13.tgz#147aad7717a7ee4211c36b21a5f4c30dddf33138"
+  dependencies:
+    "@webassemblyjs/ast" "1.5.13"
+    "@webassemblyjs/helper-buffer" "1.5.13"
+    "@webassemblyjs/wasm-gen" "1.5.13"
+    "@webassemblyjs/wasm-parser" "1.5.13"
+    debug "^3.1.0"
+
+"@webassemblyjs/wasm-parser@1.5.13":
+  version "1.5.13"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-parser/-/wasm-parser-1.5.13.tgz#6f46516c5bb23904fbdf58009233c2dd8a54c72f"
+  dependencies:
+    "@webassemblyjs/ast" "1.5.13"
+    "@webassemblyjs/helper-api-error" "1.5.13"
+    "@webassemblyjs/helper-wasm-bytecode" "1.5.13"
+    "@webassemblyjs/ieee754" "1.5.13"
+    "@webassemblyjs/leb128" "1.5.13"
+    "@webassemblyjs/utf8" "1.5.13"
+
+"@webassemblyjs/wast-parser@1.5.13":
+  version "1.5.13"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/wast-parser/-/wast-parser-1.5.13.tgz#5727a705d397ae6a3ae99d7f5460acf2ec646eea"
+  dependencies:
+    "@webassemblyjs/ast" "1.5.13"
+    "@webassemblyjs/floating-point-hex-parser" "1.5.13"
+    "@webassemblyjs/helper-api-error" "1.5.13"
+    "@webassemblyjs/helper-code-frame" "1.5.13"
+    "@webassemblyjs/helper-fsm" "1.5.13"
+    long "^3.2.0"
+    mamacro "^0.0.3"
+
+"@webassemblyjs/wast-printer@1.5.13":
+  version "1.5.13"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/wast-printer/-/wast-printer-1.5.13.tgz#bb34d528c14b4f579e7ec11e793ec50ad7cd7c95"
+  dependencies:
+    "@webassemblyjs/ast" "1.5.13"
+    "@webassemblyjs/wast-parser" "1.5.13"
+    long "^3.2.0"
+
 abab@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/abab/-/abab-1.0.4.tgz#5faad9c2c07f60dd76770f71cf025b62a63cfd4e"
@@ -206,21 +342,17 @@ accepts@~1.3.5:
     mime-types "~2.1.18"
     negotiator "0.6.1"
 
-acorn-dynamic-import@^2.0.0:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/acorn-dynamic-import/-/acorn-dynamic-import-2.0.2.tgz#c752bd210bef679501b6c6cb7fc84f8f47158cc4"
+acorn-dynamic-import@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/acorn-dynamic-import/-/acorn-dynamic-import-3.0.0.tgz#901ceee4c7faaef7e07ad2a47e890675da50a278"
   dependencies:
-    acorn "^4.0.3"
+    acorn "^5.0.0"
 
 acorn-globals@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/acorn-globals/-/acorn-globals-4.1.0.tgz#ab716025dbe17c54d3ef81d32ece2b2d99fe2538"
   dependencies:
     acorn "^5.0.0"
-
-acorn@^4.0.3:
-  version "4.0.13"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-4.0.13.tgz#105495ae5361d697bd195c825192e1ad7f253787"
 
 acorn@^5.0.0:
   version "5.2.1"
@@ -230,24 +362,17 @@ acorn@^5.5.3:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.7.1.tgz#f095829297706a7c9776958c0afc8930a9b9d9d8"
 
+acorn@^5.6.2:
+  version "5.7.2"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.7.2.tgz#91fa871883485d06708800318404e72bfb26dcc5"
+
 ajv-errors@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/ajv-errors/-/ajv-errors-1.0.0.tgz#ecf021fa108fd17dfb5e6b383f2dd233e31ffc59"
 
-ajv-keywords@^1.1.1:
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-1.5.1.tgz#314dd0a4b3368fad3dfcdc54ede6171b886daf3c"
-
 ajv-keywords@^3.1.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-3.2.0.tgz#e86b819c602cf8821ad637413698f1dec021847a"
-
-ajv@^4.7.0, ajv@^4.9.1:
-  version "4.11.8"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-4.11.8.tgz#82ffb02b29e662ae53bdc20af15947706739c536"
-  dependencies:
-    co "^4.6.0"
-    json-stable-stringify "^1.0.1"
 
 ajv@^5.0.0, ajv@^5.1.0:
   version "5.3.0"
@@ -317,13 +442,6 @@ ansi-styles@^3.2.0, ansi-styles@^3.2.1:
   dependencies:
     color-convert "^1.9.0"
 
-anymatch@^1.3.0:
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-1.3.2.tgz#553dcb8f91e3c889845dfdba34c77721b90b9d7a"
-  dependencies:
-    micromatch "^2.1.5"
-    normalize-path "^2.0.0"
-
 anymatch@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-2.0.0.tgz#bcb24b4f37934d9aa7ac17b4adaf89e7c76ef2eb"
@@ -337,7 +455,7 @@ append-transform@^1.0.0:
   dependencies:
     default-require-extensions "^2.0.0"
 
-aproba@^1.0.3:
+aproba@^1.0.3, aproba@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/aproba/-/aproba-1.2.0.tgz#6802e6264efd18c790a1b0d517f0f2627bf2c94a"
 
@@ -447,10 +565,6 @@ assert-plus@1.0.0, assert-plus@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/assert-plus/-/assert-plus-1.0.0.tgz#f12e0f3c5d77b0b1cdd9146942e4e96c1e4dd525"
 
-assert-plus@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/assert-plus/-/assert-plus-0.2.0.tgz#d74e1b87e7affc0db8aadb7021f3fe48101ab234"
-
 assert@^1.1.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/assert/-/assert-1.4.1.tgz#99912d591836b5a6f5b345c0f07eefc08fc65d91"
@@ -503,15 +617,11 @@ atob@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.1.tgz#ae2d5a729477f289d60dd7f96a6314a22dd6c22a"
 
-aws-sign2@~0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/aws-sign2/-/aws-sign2-0.6.0.tgz#14342dd38dbcc94d0e5b87d763cd63612c0e794f"
-
 aws-sign2@~0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/aws-sign2/-/aws-sign2-0.7.0.tgz#b46e890934a9591f2d2f6f86d7e6a9f1b3fe76a8"
 
-aws4@^1.2.1, aws4@^1.6.0:
+aws4@^1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.6.0.tgz#83ef5ca860b2b32e4a0deedee8c771b9db57471e"
 
@@ -785,6 +895,10 @@ block-stream@*:
   dependencies:
     inherits "~2.0.0"
 
+bluebird@^3.5.1:
+  version "3.5.2"
+  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.2.tgz#1be0908e054a751754549c270489c1505d4ab15a"
+
 bn.js@^4.0.0, bn.js@^4.1.0, bn.js@^4.1.1, bn.js@^4.4.0:
   version "4.11.8"
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.11.8.tgz#2cde09eb5ee341f484746bb0309b3253b1b1442f"
@@ -818,12 +932,6 @@ bonjour@^3.5.0:
 boolbase@^1.0.0, boolbase@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
-
-boom@2.x.x:
-  version "2.10.1"
-  resolved "https://registry.yarnpkg.com/boom/-/boom-2.10.1.tgz#39c8918ceff5799f83f9492a848f625add0c766f"
-  dependencies:
-    hoek "2.x.x"
 
 boom@4.x.x:
   version "4.3.1"
@@ -1023,6 +1131,24 @@ bytes@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.0.0.tgz#d32815404d689699f85a4ea4fa8755dd13a96048"
 
+cacache@^10.0.4:
+  version "10.0.4"
+  resolved "https://registry.yarnpkg.com/cacache/-/cacache-10.0.4.tgz#6452367999eff9d4188aefd9a14e9d7c6a263460"
+  dependencies:
+    bluebird "^3.5.1"
+    chownr "^1.0.1"
+    glob "^7.1.2"
+    graceful-fs "^4.1.11"
+    lru-cache "^4.1.1"
+    mississippi "^2.0.0"
+    mkdirp "^0.5.1"
+    move-concurrently "^1.0.1"
+    promise-inflight "^1.0.1"
+    rimraf "^2.6.2"
+    ssri "^5.2.4"
+    unique-filename "^1.1.0"
+    y18n "^4.0.0"
+
 cache-base@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/cache-base/-/cache-base-1.0.1.tgz#0a7f46416831c8b662ee36fe4e7c59d76f666ab2"
@@ -1156,22 +1282,7 @@ chardet@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"
 
-chokidar@^1.7.0:
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-1.7.0.tgz#798e689778151c8076b4b360e5edd28cda2bb468"
-  dependencies:
-    anymatch "^1.3.0"
-    async-each "^1.0.0"
-    glob-parent "^2.0.0"
-    inherits "^2.0.1"
-    is-binary-path "^1.0.0"
-    is-glob "^2.0.0"
-    path-is-absolute "^1.0.0"
-    readdirp "^2.0.0"
-  optionalDependencies:
-    fsevents "^1.0.0"
-
-chokidar@^2.0.0:
+chokidar@^2.0.0, chokidar@^2.0.2:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-2.0.4.tgz#356ff4e2b0e8e43e322d18a372460bbcf3accd26"
   dependencies:
@@ -1193,6 +1304,12 @@ chokidar@^2.0.0:
 chownr@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.0.1.tgz#e2a75042a9551908bebd25b8523d5f9769d79181"
+
+chrome-trace-event@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/chrome-trace-event/-/chrome-trace-event-1.0.0.tgz#45a91bd2c20c9411f0963b5aaeb9a1b95e09cc48"
+  dependencies:
+    tslib "^1.9.0"
 
 ci-info@^1.0.0:
   version "1.1.1"
@@ -1346,6 +1463,10 @@ commander@2.11.x, commander@~2.11.0:
   version "2.11.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.11.0.tgz#157152fd1e7a6c8d98a5b715cf376df928004563"
 
+commander@~2.13.0:
+  version "2.13.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.13.0.tgz#6964bca67685df7c1f1430c584f07d7597885b9c"
+
 commander@~2.8.1:
   version "2.8.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.8.1.tgz#06be367febfda0c330aa1e2a072d3dc9762425d4"
@@ -1390,6 +1511,15 @@ concat-stream@^1.4.6, concat-stream@^1.4.7:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.6.0.tgz#0aac662fd52be78964d5532f694784e70110acf7"
   dependencies:
+    inherits "^2.0.3"
+    readable-stream "^2.2.2"
+    typedarray "^0.0.6"
+
+concat-stream@^1.5.0:
+  version "1.6.2"
+  resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.6.2.tgz#904bdf194cd3122fc675c77fc4ac3d4ff0fd1a34"
+  dependencies:
+    buffer-from "^1.0.0"
     inherits "^2.0.3"
     readable-stream "^2.2.2"
     typedarray "^0.0.6"
@@ -1461,6 +1591,17 @@ cookie@0.3.1:
 cookiejar@^2.1.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/cookiejar/-/cookiejar-2.1.1.tgz#41ad57b1b555951ec171412a81942b1e8200d34a"
+
+copy-concurrently@^1.0.0:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/copy-concurrently/-/copy-concurrently-1.0.5.tgz#92297398cae34937fcafd6ec8139c18051f0b5e0"
+  dependencies:
+    aproba "^1.1.1"
+    fs-write-stream-atomic "^1.0.8"
+    iferr "^0.1.5"
+    mkdirp "^0.5.1"
+    rimraf "^2.5.4"
+    run-queue "^1.0.0"
 
 copy-descriptor@^0.1.0:
   version "0.1.1"
@@ -1543,12 +1684,6 @@ cross-spawn@^6.0.0, cross-spawn@^6.0.5:
     semver "^5.5.0"
     shebang-command "^1.2.0"
     which "^1.2.9"
-
-cryptiles@2.x.x:
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/cryptiles/-/cryptiles-2.0.5.tgz#3bdfecdc608147c1c67202fa291e7dca59eaa3b8"
-  dependencies:
-    boom "2.x.x"
 
 cryptiles@3.x.x:
   version "3.1.2"
@@ -1678,6 +1813,10 @@ cwebp-bin@^4.0.0:
     bin-build "^2.2.0"
     bin-wrapper "^3.0.1"
     logalot "^2.0.0"
+
+cyclist@~0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/cyclist/-/cyclist-0.2.2.tgz#1b33792e11e914a2fd6d6ed6447464444e5fa640"
 
 d@1:
   version "1.0.0"
@@ -2119,6 +2258,15 @@ duplexify@^3.2.0:
     readable-stream "^2.0.0"
     stream-shift "^1.0.0"
 
+duplexify@^3.4.2, duplexify@^3.6.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/duplexify/-/duplexify-3.6.0.tgz#592903f5d80b38d037220541264d69a198fb3410"
+  dependencies:
+    end-of-stream "^1.0.0"
+    inherits "^2.0.1"
+    readable-stream "^2.0.0"
+    stream-shift "^1.0.0"
+
 each-async@^1.0.0, each-async@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/each-async/-/each-async-1.1.1.tgz#dee5229bdf0ab6ba2012a395e1b869abf8813473"
@@ -2172,7 +2320,13 @@ end-of-stream@^1.0.0:
   dependencies:
     once "^1.4.0"
 
-enhanced-resolve@^3.0.0, enhanced-resolve@^3.3.0:
+end-of-stream@^1.1.0:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.1.tgz#ed29634d19baba463b6ce6b80a37213eab71ec43"
+  dependencies:
+    once "^1.4.0"
+
+enhanced-resolve@^3.0.0:
   version "3.4.1"
   resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-3.4.1.tgz#0421e339fd71419b3da13d129b3979040230476e"
   dependencies:
@@ -2181,7 +2335,7 @@ enhanced-resolve@^3.0.0, enhanced-resolve@^3.3.0:
     object-assign "^4.0.1"
     tapable "^0.2.7"
 
-enhanced-resolve@^4.0.0:
+enhanced-resolve@^4.0.0, enhanced-resolve@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-4.1.0.tgz#41c7e0bfdfe74ac1ffe1e57ad6a5c6c9f3742a7f"
   dependencies:
@@ -2198,6 +2352,12 @@ errno@^0.1.3:
   resolved "https://registry.yarnpkg.com/errno/-/errno-0.1.4.tgz#b896e23a9e5e8ba33871fc996abd3635fc9a1c7d"
   dependencies:
     prr "~0.0.0"
+
+errno@~0.1.7:
+  version "0.1.7"
+  resolved "https://registry.yarnpkg.com/errno/-/errno-0.1.7.tgz#4684d71779ad39af177e3f007996f7c67c852618"
+  dependencies:
+    prr "~1.0.1"
 
 error-ex@^1.2.0:
   version "1.3.1"
@@ -2283,6 +2443,13 @@ escodegen@^1.9.1:
   optionalDependencies:
     source-map "~0.6.1"
 
+eslint-scope@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-4.0.0.tgz#50bf3071e9338bcdc43331794a0cb533f0136172"
+  dependencies:
+    esrecurse "^4.1.0"
+    estraverse "^4.1.1"
+
 esprima@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-3.1.3.tgz#fdca51cee6133895e3c88d535ce49dbff62a4633"
@@ -2291,7 +2458,13 @@ esprima@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.0.tgz#4499eddcd1110e0b218bacf2fa7f7f59f55ca804"
 
-estraverse@^4.2.0:
+esrecurse@^4.1.0:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/esrecurse/-/esrecurse-4.2.1.tgz#007a3b9fdbc2b3bb87e4879ea19c92fdbd3942cf"
+  dependencies:
+    estraverse "^4.1.0"
+
+estraverse@^4.1.0, estraverse@^4.1.1, estraverse@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.2.0.tgz#0dee3fed31fcd469618ce7342099fc1afa0bdb13"
 
@@ -2524,7 +2697,7 @@ extend-shallow@^3.0.0, extend-shallow@^3.0.2:
     assign-symbols "^1.0.0"
     is-extendable "^1.0.1"
 
-extend@^3.0.0, extend@~3.0.0, extend@~3.0.1:
+extend@^3.0.0, extend@~3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.1.tgz#a755ea7bc1adfcc5a31ce7e762dbaadc5e636444"
 
@@ -2797,6 +2970,13 @@ first-chunk-stream@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz#59bfb50cd905f60d7c394cd3d9acaab4e6ad934e"
 
+flush-write-stream@^1.0.0:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/flush-write-stream/-/flush-write-stream-1.0.3.tgz#c5d586ef38af6097650b49bc41b55fabb19f35bd"
+  dependencies:
+    inherits "^2.0.1"
+    readable-stream "^2.0.4"
+
 for-in@^0.1.3:
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/for-in/-/for-in-0.1.8.tgz#d8773908e31256109952b1fdb9b3fa867d2775e1"
@@ -2833,14 +3013,6 @@ form-data@^2.3.1, form-data@~2.3.1:
     combined-stream "^1.0.5"
     mime-types "^2.1.12"
 
-form-data@~2.1.1:
-  version "2.1.4"
-  resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.1.4.tgz#33c183acf193276ecaa98143a69e94bfee1750d1"
-  dependencies:
-    asynckit "^0.4.0"
-    combined-stream "^1.0.5"
-    mime-types "^2.1.12"
-
 formidable@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/formidable/-/formidable-1.1.1.tgz#96b8886f7c3c3508b932d6bd70c4d3a88f35f1a9"
@@ -2858,6 +3030,13 @@ fragment-cache@^0.2.1:
 fresh@0.5.2:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/fresh/-/fresh-0.5.2.tgz#3d8cadd90d976569fa835ab1f8e4b23a105605a7"
+
+from2@^2.1.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/from2/-/from2-2.3.0.tgz#8bfb5502bde4a4d36cfdeea007fcca21d7e382af"
+  dependencies:
+    inherits "^2.0.1"
+    readable-stream "^2.0.0"
 
 fs-constants@^1.0.0:
   version "1.0.0"
@@ -2877,16 +3056,18 @@ fs-minipass@^1.2.5:
   dependencies:
     minipass "^2.2.1"
 
+fs-write-stream-atomic@^1.0.8:
+  version "1.0.10"
+  resolved "https://registry.yarnpkg.com/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz#b47df53493ef911df75731e70a9ded0189db40c9"
+  dependencies:
+    graceful-fs "^4.1.2"
+    iferr "^0.1.5"
+    imurmurhash "^0.1.4"
+    readable-stream "1 || 2"
+
 fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
-
-fsevents@^1.0.0:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-1.1.3.tgz#11f82318f5fe7bb2cd22965a108e9306208216d8"
-  dependencies:
-    nan "^2.3.0"
-    node-pre-gyp "^0.6.39"
 
 fsevents@^1.2.2, fsevents@^1.2.3:
   version "1.2.4"
@@ -2895,15 +3076,7 @@ fsevents@^1.2.2, fsevents@^1.2.3:
     nan "^2.9.2"
     node-pre-gyp "^0.10.0"
 
-fstream-ignore@^1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/fstream-ignore/-/fstream-ignore-1.0.5.tgz#9c31dae34767018fe1d249b24dada67d092da105"
-  dependencies:
-    fstream "^1.0.0"
-    inherits "2"
-    minimatch "^3.0.0"
-
-fstream@^1.0.0, fstream@^1.0.10, fstream@^1.0.2:
+fstream@^1.0.0, fstream@^1.0.2:
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/fstream/-/fstream-1.0.11.tgz#5c1fb1f117477114f0632a0eb4b71b3cb0fd3171"
   dependencies:
@@ -3239,20 +3412,9 @@ handlebars@^4.0.3:
   optionalDependencies:
     uglify-js "^2.6"
 
-har-schema@^1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/har-schema/-/har-schema-1.0.5.tgz#d263135f43307c02c602afc8fe95970c0151369e"
-
 har-schema@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/har-schema/-/har-schema-2.0.0.tgz#a94c2224ebcac04782a0d9035521f24735b7ec92"
-
-har-validator@~4.2.1:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/har-validator/-/har-validator-4.2.1.tgz#33481d0f1bbff600dd203d75812a6a5fba002e2a"
-  dependencies:
-    ajv "^4.9.1"
-    har-schema "^1.0.5"
 
 har-validator@~5.0.3:
   version "5.0.3"
@@ -3356,15 +3518,6 @@ hash.js@^1.0.0, hash.js@^1.0.3:
     inherits "^2.0.3"
     minimalistic-assert "^1.0.0"
 
-hawk@3.1.3, hawk@~3.1.3:
-  version "3.1.3"
-  resolved "https://registry.yarnpkg.com/hawk/-/hawk-3.1.3.tgz#078444bd7c1640b0fe540d2c9b73d59678e8e1c4"
-  dependencies:
-    boom "2.x.x"
-    cryptiles "2.x.x"
-    hoek "2.x.x"
-    sntp "1.x.x"
-
 hawk@~6.0.2:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/hawk/-/hawk-6.0.2.tgz#af4d914eb065f9b5ce4d9d11c1cb2126eecc3038"
@@ -3404,10 +3557,6 @@ hmac-drbg@^1.0.0:
     hash.js "^1.0.3"
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
-
-hoek@2.x.x:
-  version "2.16.3"
-  resolved "https://registry.yarnpkg.com/hoek/-/hoek-2.16.3.tgz#20bb7403d3cea398e91dc4710a8ff1b8274a25ed"
 
 hoek@4.x.x:
   version "4.2.0"
@@ -3522,14 +3671,6 @@ http-proxy@^1.16.2:
     eventemitter3 "1.x.x"
     requires-port "1.x.x"
 
-http-signature@~1.1.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/http-signature/-/http-signature-1.1.1.tgz#df72e267066cd0ac67fb76adf8e134a8fbcf91bf"
-  dependencies:
-    assert-plus "^0.2.0"
-    jsprim "^1.2.2"
-    sshpk "^1.7.0"
-
 http-signature@~1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/http-signature/-/http-signature-1.2.0.tgz#9aecd925114772f3d95b65a60abb8f7c18fbace1"
@@ -3568,9 +3709,17 @@ icss-utils@^2.1.0:
   dependencies:
     postcss "^6.0.1"
 
+ieee754@^1.1.11:
+  version "1.1.12"
+  resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.12.tgz#50bf24e5b9c8bb98af4964c941cdb0918da7b60b"
+
 ieee754@^1.1.4:
   version "1.1.8"
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.8.tgz#be33d40ac10ef1926701f6f08a2d86fbfd1ad3e4"
+
+iferr@^0.1.5:
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/iferr/-/iferr-0.1.5.tgz#c60eed69e6d8fdb6b3104a1fcbca1c192dc5b501"
 
 ignore-walk@^3.0.1:
   version "3.0.1"
@@ -3723,10 +3872,6 @@ internal-ip@1.2.0:
   resolved "https://registry.yarnpkg.com/internal-ip/-/internal-ip-1.2.0.tgz#ae9fbf93b984878785d50a8de1b356956058cf5c"
   dependencies:
     meow "^3.3.0"
-
-interpret@^1.0.0:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.0.4.tgz#820cdd588b868ffb191a809506d6c9c8f212b1b0"
 
 interpret@^1.1.0:
   version "1.1.0"
@@ -4621,6 +4766,10 @@ json-loader@^0.5.4:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/json-loader/-/json-loader-0.5.7.tgz#dca14a70235ff82f0ac9a3abeb60d337a365185d"
 
+json-parse-better-errors@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz#bb867cfb3450e69107c131d1c514bab3dc8bcaa9"
+
 json-schema-traverse@^0.3.0:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz#349a6d44c53a51de89b40805c5d5e59b417d3340"
@@ -4633,7 +4782,7 @@ json-schema@0.2.3:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/json-schema/-/json-schema-0.2.3.tgz#b480c892e59a2f05954ce727bd3f2a4e882f9e13"
 
-json-stable-stringify@^1.0.0, json-stable-stringify@^1.0.1:
+json-stable-stringify@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz#9a759d39c5f2ff503fd5300646ed445f88c4f9af"
   dependencies:
@@ -4947,6 +5096,14 @@ loglevelnext@^1.0.1:
     es6-symbol "^3.1.1"
     object.assign "^4.1.0"
 
+long@4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/long/-/long-4.0.0.tgz#9a7b71cfb7d361a194ea555241c92f7468d5bf28"
+
+long@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/long/-/long-3.2.0.tgz#d821b7138ca1cb581c172990ef14db200b5c474b"
+
 longest@^1.0.0, longest@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/longest/-/longest-1.0.1.tgz#30a0b2da38f73770e8294a0d22e6625ed77d0097"
@@ -4988,6 +5145,13 @@ lru-cache@^4.0.1:
     pseudomap "^1.0.2"
     yallist "^2.1.2"
 
+lru-cache@^4.1.1:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.3.tgz#a1175cf3496dfc8436c156c334b4955992bce69c"
+  dependencies:
+    pseudomap "^1.0.2"
+    yallist "^2.1.2"
+
 make-dir@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-1.1.0.tgz#19b4369fe48c116f53c2af95ad102c0e39e85d51"
@@ -4999,6 +5163,10 @@ makeerror@1.0.x:
   resolved "https://registry.yarnpkg.com/makeerror/-/makeerror-1.0.11.tgz#e01a5c9109f2af79660e4e8b9587790184f5a96c"
   dependencies:
     tmpl "1.0.x"
+
+mamacro@^0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/mamacro/-/mamacro-0.0.3.tgz#ad2c9576197c9f1abf308d0787865bd975a3f3e4"
 
 map-cache@^0.2.2:
   version "0.2.2"
@@ -5088,7 +5256,7 @@ methods@^1.1.1, methods@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"
 
-micromatch@^2.1.5, micromatch@^2.3.11, micromatch@^2.3.7:
+micromatch@^2.3.11, micromatch@^2.3.7:
   version "2.3.11"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-2.3.11.tgz#86677c97d1720b363431d04d0d15293bd38c1565"
   dependencies:
@@ -5143,7 +5311,7 @@ mime-db@~1.30.0:
   version "1.30.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.30.0.tgz#74c643da2dd9d6a45399963465b26d5ca7d71f01"
 
-mime-types@^2.1.12, mime-types@~2.1.15, mime-types@~2.1.16, mime-types@~2.1.17, mime-types@~2.1.7:
+mime-types@^2.1.12, mime-types@~2.1.15, mime-types@~2.1.16, mime-types@~2.1.17:
   version "2.1.17"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.17.tgz#09d7a393f03e995a79f8af857b70a9e0ab16557a"
   dependencies:
@@ -5179,7 +5347,7 @@ minimalistic-crypto-utils@^1.0.0, minimalistic-crypto-utils@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz#f6c00c1c0b082246e5c4d99dfb8c7c083b2b582a"
 
-"minimatch@2 || 3", minimatch@^3.0.0, minimatch@^3.0.2, minimatch@^3.0.3, minimatch@^3.0.4, minimatch@~3.0.2:
+"minimatch@2 || 3", minimatch@^3.0.2, minimatch@^3.0.3, minimatch@^3.0.4, minimatch@~3.0.2:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
   dependencies:
@@ -5210,6 +5378,21 @@ minizlib@^1.1.0:
   dependencies:
     minipass "^2.2.1"
 
+mississippi@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/mississippi/-/mississippi-2.0.0.tgz#3442a508fafc28500486feea99409676e4ee5a6f"
+  dependencies:
+    concat-stream "^1.5.0"
+    duplexify "^3.4.2"
+    end-of-stream "^1.1.0"
+    flush-write-stream "^1.0.0"
+    from2 "^2.1.0"
+    parallel-transform "^1.1.0"
+    pump "^2.0.1"
+    pumpify "^1.3.3"
+    stream-each "^1.1.0"
+    through2 "^2.0.0"
+
 mixin-deep@^1.2.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/mixin-deep/-/mixin-deep-1.3.1.tgz#a49e7268dce1a0d9698e45326c5626df3543d0fe"
@@ -5239,6 +5422,17 @@ mock-socket@^8.0.0:
 moment@^2.13.0:
   version "2.19.2"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.19.2.tgz#8a7f774c95a64550b4c7ebd496683908f9419dbe"
+
+move-concurrently@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/move-concurrently/-/move-concurrently-1.0.1.tgz#be2c005fda32e0b29af1f05d7c4b33214c701f92"
+  dependencies:
+    aproba "^1.1.1"
+    copy-concurrently "^1.0.0"
+    fs-write-stream-atomic "^1.0.8"
+    mkdirp "^0.5.1"
+    rimraf "^2.5.4"
+    run-queue "^1.0.3"
 
 mozjpeg@^5.0.0:
   version "5.0.0"
@@ -5273,7 +5467,7 @@ mute-stream@0.0.7:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz#3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab"
 
-nan@^2.3.0, nan@^2.3.2, nan@^2.3.3:
+nan@^2.3.2, nan@^2.3.3:
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.7.0.tgz#d95bf721ec877e08db276ed3fc6eb78f9083ad46"
 
@@ -5422,22 +5616,6 @@ node-pre-gyp@^0.10.0:
     semver "^5.3.0"
     tar "^4"
 
-node-pre-gyp@^0.6.39:
-  version "0.6.39"
-  resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.6.39.tgz#c00e96860b23c0e1420ac7befc5044e1d78d8649"
-  dependencies:
-    detect-libc "^1.0.2"
-    hawk "3.1.3"
-    mkdirp "^0.5.1"
-    nopt "^4.0.1"
-    npmlog "^4.0.2"
-    rc "^1.1.7"
-    request "2.81.0"
-    rimraf "^2.6.1"
-    semver "^5.3.0"
-    tar "^2.2.1"
-    tar-pack "^3.4.0"
-
 node-sass@^4.0.0:
   version "4.6.1"
   resolved "https://registry.yarnpkg.com/node-sass/-/node-sass-4.6.1.tgz#9b331cf943ee5440f199e858941a90d13bc9bfc5"
@@ -5487,7 +5665,7 @@ normalize-package-data@^2.3.2, normalize-package-data@^2.3.4:
     semver "2 || 3 || 4 || 5"
     validate-npm-package-license "^3.0.1"
 
-normalize-path@^2.0.0, normalize-path@^2.0.1, normalize-path@^2.1.1:
+normalize-path@^2.0.1, normalize-path@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-2.1.1.tgz#1ab28b556e198363a8c1a6f7e6fa20137fe6aed9"
   dependencies:
@@ -5540,7 +5718,7 @@ nwsapi@^2.0.7:
   version "2.0.8"
   resolved "https://registry.yarnpkg.com/nwsapi/-/nwsapi-2.0.8.tgz#e3603579b7e162b3dbedae4fb24e46f771d8fa24"
 
-oauth-sign@~0.8.1, oauth-sign@~0.8.2:
+oauth-sign@~0.8.2:
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.8.2.tgz#46a6ab7f0aead8deae9ec0565780b7d4efeb9d43"
 
@@ -5630,7 +5808,7 @@ on-headers@~1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/on-headers/-/on-headers-1.0.1.tgz#928f5d0f470d49342651ea6794b0857c100693f7"
 
-once@^1.3.0, once@^1.3.3, once@^1.4.0:
+once@^1.3.0, once@^1.3.1, once@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
   dependencies:
@@ -5808,6 +5986,14 @@ pako@^1.0.3:
 pako@~0.2.0:
   version "0.2.9"
   resolved "https://registry.yarnpkg.com/pako/-/pako-0.2.9.tgz#f3f7522f4ef782348da8161bad9ecfd51bf83a75"
+
+parallel-transform@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/parallel-transform/-/parallel-transform-1.1.0.tgz#d410f065b05da23081fcd10f28854c29bda33b06"
+  dependencies:
+    cyclist "~0.2.2"
+    inherits "^2.0.3"
+    readable-stream "^2.1.5"
 
 param-case@2.1.x:
   version "2.1.1"
@@ -6075,6 +6261,10 @@ process@^0.11.0:
   version "0.11.10"
   resolved "https://registry.yarnpkg.com/process/-/process-0.11.10.tgz#7332300e840161bda3e69a1d1d91a7d4bc16f182"
 
+promise-inflight@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/promise-inflight/-/promise-inflight-1.0.1.tgz#98472870bf228132fcbdd868129bad12c3c029e3"
+
 promise@^7.1.1:
   version "7.3.1"
   resolved "https://registry.yarnpkg.com/promise/-/promise-7.3.1.tgz#064b72602b18f90f29192b8b1bc418ffd1ebd3bf"
@@ -6124,6 +6314,10 @@ prr@~0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/prr/-/prr-0.0.0.tgz#1a84b85908325501411853d0081ee3fa86e2926a"
 
+prr@~1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/prr/-/prr-1.0.1.tgz#d3fc114ba06995a45ec6893f484ceb1d78f5f476"
+
 pseudomap@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
@@ -6141,6 +6335,21 @@ public-encrypt@^4.0.0:
     create-hash "^1.1.0"
     parse-asn1 "^5.0.0"
     randombytes "^2.0.1"
+
+pump@^2.0.0, pump@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/pump/-/pump-2.0.1.tgz#12399add6e4cf7526d973cbc8b5ce2e2908b3909"
+  dependencies:
+    end-of-stream "^1.1.0"
+    once "^1.3.1"
+
+pumpify@^1.3.3:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/pumpify/-/pumpify-1.5.1.tgz#36513be246ab27570b1a374a5ce278bfd74370ce"
+  dependencies:
+    duplexify "^3.6.0"
+    inherits "^2.0.3"
+    pump "^2.0.0"
 
 punycode@1.3.2:
   version "1.3.2"
@@ -6161,10 +6370,6 @@ q@^1.1.2:
 qs@6.5.1, qs@^6.5.1, qs@~6.5.1:
   version "6.5.1"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.1.tgz#349cdf6eef89ec45c12d7d5eb3fc0c870343a6d8"
-
-qs@~6.4.0:
-  version "6.4.0"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.4.0.tgz#13e26d28ad6b0ffaa91312cd3bf708ed351e7233"
 
 query-string@^4.2.2:
   version "4.3.4"
@@ -6232,7 +6437,7 @@ raw-body@2.3.2:
     iconv-lite "0.4.19"
     unpipe "1.0.0"
 
-rc@^1.0.1, rc@^1.1.2, rc@^1.1.6, rc@^1.1.7:
+rc@^1.0.1, rc@^1.1.2, rc@^1.1.6:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.2.tgz#d8ce9cb57e8d64d9c7badd9876c7c34cbe3c7077"
   dependencies:
@@ -6392,28 +6597,7 @@ read-pkg@^1.0.0:
     normalize-package-data "^2.3.2"
     path-type "^1.0.0"
 
-readable-stream@1.0, "readable-stream@>=1.0.33-1 <1.1.0-0":
-  version "1.0.34"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-1.0.34.tgz#125820e34bc842d2f2aaafafe4c2916ee32c157c"
-  dependencies:
-    core-util-is "~1.0.0"
-    inherits "~2.0.1"
-    isarray "0.0.1"
-    string_decoder "~0.10.x"
-
-readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.4, readable-stream@^2.0.5, readable-stream@^2.0.6, readable-stream@^2.1.4, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.2.6, readable-stream@^2.2.9:
-  version "2.3.3"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.3.tgz#368f2512d79f9d46fdfc71349ae7878bbc1eb95c"
-  dependencies:
-    core-util-is "~1.0.0"
-    inherits "~2.0.3"
-    isarray "~1.0.0"
-    process-nextick-args "~1.0.6"
-    safe-buffer "~5.1.1"
-    string_decoder "~1.0.3"
-    util-deprecate "~1.0.1"
-
-readable-stream@^2.3.0:
+"readable-stream@1 || 2", readable-stream@^2.3.0:
   version "2.3.6"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.6.tgz#b11c27d88b8ff1fbe070643cf94b0c79ae1b0aaf"
   dependencies:
@@ -6423,6 +6607,27 @@ readable-stream@^2.3.0:
     process-nextick-args "~2.0.0"
     safe-buffer "~5.1.1"
     string_decoder "~1.1.1"
+    util-deprecate "~1.0.1"
+
+readable-stream@1.0, "readable-stream@>=1.0.33-1 <1.1.0-0":
+  version "1.0.34"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-1.0.34.tgz#125820e34bc842d2f2aaafafe4c2916ee32c157c"
+  dependencies:
+    core-util-is "~1.0.0"
+    inherits "~2.0.1"
+    isarray "0.0.1"
+    string_decoder "~0.10.x"
+
+readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.4, readable-stream@^2.0.5, readable-stream@^2.0.6, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.2.6, readable-stream@^2.2.9:
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.3.tgz#368f2512d79f9d46fdfc71349ae7878bbc1eb95c"
+  dependencies:
+    core-util-is "~1.0.0"
+    inherits "~2.0.3"
+    isarray "~1.0.0"
+    process-nextick-args "~1.0.6"
+    safe-buffer "~5.1.1"
+    string_decoder "~1.0.3"
     util-deprecate "~1.0.1"
 
 readable-stream@~1.1.9:
@@ -6639,33 +6844,6 @@ request@2, request@^2.79.0:
     tunnel-agent "^0.6.0"
     uuid "^3.1.0"
 
-request@2.81.0:
-  version "2.81.0"
-  resolved "https://registry.yarnpkg.com/request/-/request-2.81.0.tgz#c6928946a0e06c5f8d6f8a9333469ffda46298a0"
-  dependencies:
-    aws-sign2 "~0.6.0"
-    aws4 "^1.2.1"
-    caseless "~0.12.0"
-    combined-stream "~1.0.5"
-    extend "~3.0.0"
-    forever-agent "~0.6.1"
-    form-data "~2.1.1"
-    har-validator "~4.2.1"
-    hawk "~3.1.3"
-    http-signature "~1.1.0"
-    is-typedarray "~1.0.0"
-    isstream "~0.1.2"
-    json-stringify-safe "~5.0.1"
-    mime-types "~2.1.7"
-    oauth-sign "~0.8.1"
-    performance-now "^0.2.0"
-    qs "~6.4.0"
-    safe-buffer "^5.0.1"
-    stringstream "~0.0.4"
-    tough-cookie "~2.3.0"
-    tunnel-agent "^0.6.0"
-    uuid "^3.0.0"
-
 request@^2.87.0:
   version "2.87.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.87.0.tgz#32f00235cd08d482b4d0d68db93a829c0ed5756e"
@@ -6752,7 +6930,7 @@ right-align@^0.1.1:
   dependencies:
     align-text "^0.1.1"
 
-rimraf@2, rimraf@^2.2.6, rimraf@^2.2.8, rimraf@^2.4.4, rimraf@^2.5.1, rimraf@^2.5.4, rimraf@^2.6.1:
+rimraf@2, rimraf@^2.2.6, rimraf@^2.2.8, rimraf@^2.4.4, rimraf@^2.5.4, rimraf@^2.6.1, rimraf@^2.6.2:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.2.tgz#2ed8150d24a16ea8651e6d6ef0f47c4158ce7a36"
   dependencies:
@@ -6774,6 +6952,12 @@ run-async@^2.2.0:
   resolved "https://registry.yarnpkg.com/run-async/-/run-async-2.3.0.tgz#0371ab4ae0bdd720d4166d7dfda64ff7a445a6c0"
   dependencies:
     is-promise "^2.1.0"
+
+run-queue@^1.0.0, run-queue@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/run-queue/-/run-queue-1.0.3.tgz#e848396f057d223f24386924618e25694161ec47"
+  dependencies:
+    aproba "^1.1.1"
 
 rxjs-compat@^6:
   version "6.2.2"
@@ -6853,6 +7037,13 @@ schema-utils@^0.3.0:
   resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-0.3.0.tgz#f5877222ce3e931edae039f17eb3716e7137f8cf"
   dependencies:
     ajv "^5.0.0"
+
+schema-utils@^0.4.4:
+  version "0.4.7"
+  resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-0.4.7.tgz#ba74f597d2be2ea880131746ee17d0a093c68187"
+  dependencies:
+    ajv "^6.1.0"
+    ajv-keywords "^3.1.0"
 
 schema-utils@^0.4.5:
   version "0.4.5"
@@ -6959,6 +7150,10 @@ send@0.16.2:
     on-finished "~2.3.0"
     range-parser "~1.2.0"
     statuses "~1.4.0"
+
+serialize-javascript@^1.4.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-1.5.0.tgz#1aa336162c88a890ddad5384baebc93a655161fe"
 
 serve-index@^1.7.2:
   version "1.9.1"
@@ -7095,12 +7290,6 @@ snapdragon@^0.8.1:
     source-map "^0.5.6"
     source-map-resolve "^0.5.0"
     use "^3.1.0"
-
-sntp@1.x.x:
-  version "1.0.9"
-  resolved "https://registry.yarnpkg.com/sntp/-/sntp-1.0.9.tgz#6541184cc90aeea6c6e7b35e2659082443c66198"
-  dependencies:
-    hoek "2.x.x"
 
 sntp@2.x.x:
   version "2.1.0"
@@ -7264,6 +7453,12 @@ sshpk@^1.7.0:
     jsbn "~0.1.0"
     tweetnacl "~0.14.0"
 
+ssri@^5.2.4:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/ssri/-/ssri-5.3.0.tgz#ba3872c9c6d33a0704a7d71ff045e5ec48999d06"
+  dependencies:
+    safe-buffer "^5.1.1"
+
 stable@~0.1.6:
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/stable/-/stable-0.1.8.tgz#836eb3c8382fe2936feaf544631017ce7d47a3cf"
@@ -7318,6 +7513,13 @@ stream-combiner2@^1.1.1:
   dependencies:
     duplexer2 "~0.1.0"
     readable-stream "^2.0.2"
+
+stream-each@^1.1.0:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/stream-each/-/stream-each-1.2.3.tgz#ebe27a0c389b04fbcc233642952e10731afa9bae"
+  dependencies:
+    end-of-stream "^1.1.0"
+    stream-shift "^1.0.0"
 
 stream-http@^2.3.1:
   version "2.7.2"
@@ -7375,7 +7577,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-stringstream@~0.0.4, stringstream@~0.0.5:
+stringstream@~0.0.5:
   version "0.0.5"
   resolved "https://registry.yarnpkg.com/stringstream/-/stringstream-0.0.5.tgz#4e484cd4de5a0bbbee18e46307710a8a81621878"
 
@@ -7477,7 +7679,7 @@ supports-color@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
 
-supports-color@^3.1.0, supports-color@^3.1.2:
+supports-color@^3.1.2:
   version "3.2.3"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-3.2.3.tgz#65ac0504b3954171d8a64946b2ae3cbb8a5f54f6"
   dependencies:
@@ -7526,26 +7728,13 @@ symbol-tree@^3.2.2:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.2.tgz#ae27db38f660a7ae2e1c3b7d1bc290819b8519e6"
 
-tapable@^0.2.7, tapable@~0.2.5:
+tapable@^0.2.7:
   version "0.2.8"
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-0.2.8.tgz#99372a5c999bf2df160afc0d74bed4f47948cd22"
 
 tapable@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-1.0.0.tgz#cbb639d9002eed9c6b5975eb20598d7936f1f9f2"
-
-tar-pack@^3.4.0:
-  version "3.4.1"
-  resolved "https://registry.yarnpkg.com/tar-pack/-/tar-pack-3.4.1.tgz#e1dbc03a9b9d3ba07e896ad027317eb679a10a1f"
-  dependencies:
-    debug "^2.2.0"
-    fstream "^1.0.10"
-    fstream-ignore "^1.0.5"
-    once "^1.3.3"
-    readable-stream "^2.1.4"
-    rimraf "^2.5.1"
-    tar "^2.2.1"
-    uid-number "^0.0.6"
 
 tar-stream@^1.1.1:
   version "1.5.5"
@@ -7568,7 +7757,7 @@ tar-stream@^1.5.2:
     to-buffer "^1.1.0"
     xtend "^4.0.0"
 
-tar@^2.0.0, tar@^2.2.1:
+tar@^2.0.0:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/tar/-/tar-2.2.1.tgz#8e4d2a256c0e2185c6b18ad694aec968b83cb1d1"
   dependencies:
@@ -7734,7 +7923,7 @@ tough-cookie@>=2.3.3, tough-cookie@^2.3.4:
     psl "^1.1.24"
     punycode "^1.4.1"
 
-tough-cookie@~2.3.0, tough-cookie@~2.3.3:
+tough-cookie@~2.3.3:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.3.3.tgz#0b618a5565b6dea90bf3425d04d55edc475a7561"
   dependencies:
@@ -7877,6 +8066,13 @@ ua-parser-js@^0.7.9:
   version "0.7.17"
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.17.tgz#e9ec5f9498b9ec910e7ae3ac626a805c4d09ecac"
 
+uglify-es@^3.3.4:
+  version "3.3.9"
+  resolved "https://registry.yarnpkg.com/uglify-es/-/uglify-es-3.3.9.tgz#0c1c4f0700bed8dbc124cdb304d2592ca203e677"
+  dependencies:
+    commander "~2.13.0"
+    source-map "~0.6.1"
+
 uglify-js@3.1.x:
   version "3.1.9"
   resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.1.9.tgz#dffca799308cf327ec3ac77eeacb8e196ce3b452"
@@ -7884,7 +8080,7 @@ uglify-js@3.1.x:
     commander "~2.11.0"
     source-map "~0.6.1"
 
-uglify-js@^2.6, uglify-js@^2.8.27:
+uglify-js@^2.6:
   version "2.8.29"
   resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-2.8.29.tgz#29c5733148057bb4e1f75df35b7a9cb72e6a59dd"
   dependencies:
@@ -7897,9 +8093,18 @@ uglify-to-browserify@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz#6e0924d6bda6b5afe349e39a6d632850a0f882b7"
 
-uid-number@^0.0.6:
-  version "0.0.6"
-  resolved "https://registry.yarnpkg.com/uid-number/-/uid-number-0.0.6.tgz#0ea10e8035e8eb5b8e4449f06da1c730663baa81"
+uglifyjs-webpack-plugin@^1.2.4:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-1.3.0.tgz#75f548160858163a08643e086d5fefe18a5d67de"
+  dependencies:
+    cacache "^10.0.4"
+    find-cache-dir "^1.0.0"
+    schema-utils "^0.4.5"
+    serialize-javascript "^1.4.0"
+    source-map "^0.6.1"
+    uglify-es "^3.3.4"
+    webpack-sources "^1.1.0"
+    worker-farm "^1.5.2"
 
 unbzip2-stream@^1.0.9:
   version "1.2.5"
@@ -7935,6 +8140,18 @@ union-value@^1.0.0:
     get-value "^2.0.6"
     is-extendable "^0.1.1"
     set-value "^0.4.3"
+
+unique-filename@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/unique-filename/-/unique-filename-1.1.0.tgz#d05f2fe4032560871f30e93cbe735eea201514f3"
+  dependencies:
+    unique-slug "^2.0.0"
+
+unique-slug@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/unique-slug/-/unique-slug-2.0.0.tgz#db6676e7c7cc0629878ff196097c78855ae9f4ab"
+  dependencies:
+    imurmurhash "^0.1.4"
 
 unique-stream@^2.0.2:
   version "2.2.1"
@@ -8107,7 +8324,7 @@ uuid@^2.0.1:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-2.0.3.tgz#67e2e863797215530dff318e5bf9dcebfd47b21a"
 
-uuid@^3.0.0, uuid@^3.0.1, uuid@^3.1.0:
+uuid@^3.0.1, uuid@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.1.0.tgz#3dd3d3e790abc24d7b0d3a034ffababe28ebbc04"
 
@@ -8243,13 +8460,13 @@ watch@~0.18.0:
     exec-sh "^0.2.0"
     minimist "^1.2.0"
 
-watchpack@^1.3.1:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/watchpack/-/watchpack-1.4.0.tgz#4a1472bcbb952bd0a9bb4036801f954dfb39faac"
+watchpack@^1.5.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/watchpack/-/watchpack-1.6.0.tgz#4bc12c2ebe8aa277a71f1d3f14d685c7b446cd00"
   dependencies:
-    async "^2.1.2"
-    chokidar "^1.7.0"
+    chokidar "^2.0.2"
     graceful-fs "^4.1.2"
+    neo-async "^2.5.0"
 
 wbuf@^1.1.0, wbuf@^1.7.2:
   version "1.7.2"
@@ -8338,31 +8555,42 @@ webpack-sources@^1.0.1:
     source-list-map "^2.0.0"
     source-map "~0.6.1"
 
-webpack@^2.2.1:
-  version "2.7.0"
-  resolved "https://registry.yarnpkg.com/webpack/-/webpack-2.7.0.tgz#b2a1226804373ffd3d03ea9c6bd525067034f6b1"
+webpack-sources@^1.1.0, webpack-sources@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-1.2.0.tgz#18181e0d013fce096faf6f8e6d41eeffffdceac2"
   dependencies:
-    acorn "^5.0.0"
-    acorn-dynamic-import "^2.0.0"
-    ajv "^4.7.0"
-    ajv-keywords "^1.1.1"
-    async "^2.1.2"
-    enhanced-resolve "^3.3.0"
-    interpret "^1.0.0"
-    json-loader "^0.5.4"
-    json5 "^0.5.1"
+    source-list-map "^2.0.0"
+    source-map "~0.6.1"
+
+webpack@^4.0.0:
+  version "4.17.2"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-4.17.2.tgz#49feb20205bd15f0a5f1fe0a12097d5d9931878d"
+  dependencies:
+    "@webassemblyjs/ast" "1.5.13"
+    "@webassemblyjs/helper-module-context" "1.5.13"
+    "@webassemblyjs/wasm-edit" "1.5.13"
+    "@webassemblyjs/wasm-opt" "1.5.13"
+    "@webassemblyjs/wasm-parser" "1.5.13"
+    acorn "^5.6.2"
+    acorn-dynamic-import "^3.0.0"
+    ajv "^6.1.0"
+    ajv-keywords "^3.1.0"
+    chrome-trace-event "^1.0.0"
+    enhanced-resolve "^4.1.0"
+    eslint-scope "^4.0.0"
+    json-parse-better-errors "^1.0.2"
     loader-runner "^2.3.0"
-    loader-utils "^0.2.16"
+    loader-utils "^1.1.0"
     memory-fs "~0.4.1"
+    micromatch "^3.1.8"
     mkdirp "~0.5.0"
+    neo-async "^2.5.0"
     node-libs-browser "^2.0.0"
-    source-map "^0.5.3"
-    supports-color "^3.1.0"
-    tapable "~0.2.5"
-    uglify-js "^2.8.27"
-    watchpack "^1.3.1"
-    webpack-sources "^1.0.1"
-    yargs "^6.0.0"
+    schema-utils "^0.4.4"
+    tapable "^1.0.0"
+    uglifyjs-webpack-plugin "^1.2.4"
+    watchpack "^1.5.0"
+    webpack-sources "^1.2.0"
 
 websocket-driver@>=0.5.1:
   version "0.7.0"
@@ -8454,6 +8682,12 @@ wordwrap@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
 
+worker-farm@^1.5.2:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/worker-farm/-/worker-farm-1.6.0.tgz#aecc405976fab5a95526180846f0dba288f3a4a0"
+  dependencies:
+    errno "~0.1.7"
+
 wrap-ansi@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-2.1.0.tgz#d8fc3d284dd05794fe84973caecdd1cf824fdd85"
@@ -8532,7 +8766,7 @@ y18n@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-3.2.1.tgz#6d15fba884c08679c0d77e88e7759e811e07fa41"
 
-"y18n@^3.2.1 || ^4.0.0":
+"y18n@^3.2.1 || ^4.0.0", y18n@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.0.tgz#95ef94f85ecc81d007c264e190a120f0a3c8566b"
 
@@ -8553,12 +8787,6 @@ yargs-parser@^10.1.0:
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-10.1.0.tgz#7202265b89f7e9e9f2e5765e0fe735a905edbaa8"
   dependencies:
     camelcase "^4.1.0"
-
-yargs-parser@^4.2.0:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-4.2.1.tgz#29cceac0dc4f03c6c87b4a9f217dd18c9f74871c"
-  dependencies:
-    camelcase "^3.0.0"
 
 yargs-parser@^5.0.0:
   version "5.0.0"
@@ -8622,24 +8850,6 @@ yargs@^12.0.1:
     which-module "^2.0.0"
     y18n "^3.2.1 || ^4.0.0"
     yargs-parser "^10.1.0"
-
-yargs@^6.0.0:
-  version "6.6.0"
-  resolved "https://registry.yarnpkg.com/yargs/-/yargs-6.6.0.tgz#782ec21ef403345f830a808ca3d513af56065208"
-  dependencies:
-    camelcase "^3.0.0"
-    cliui "^3.2.0"
-    decamelize "^1.1.1"
-    get-caller-file "^1.0.1"
-    os-locale "^1.4.0"
-    read-pkg-up "^1.0.1"
-    require-directory "^2.1.1"
-    require-main-filename "^1.0.1"
-    set-blocking "^2.0.0"
-    string-width "^1.0.2"
-    which-module "^1.0.0"
-    y18n "^3.2.1"
-    yargs-parser "^4.2.0"
 
 yargs@^7.0.0:
   version "7.1.0"


### PR DESCRIPTION
<p>This Pull Request updates dependency <a href="https://renovatebot.com/gh/webpack/webpack">webpack</a> from <code>^2.2.1</code> to <code>^4.0.0</code></p>
<p><details><br />
<summary>Release Notes</summary></p>
<h3 id="v4172httpsgithubcomwebpackwebpackreleasesv4172"><a href="https://renovatebot.com/gh/webpack/webpack/releases/v4.17.2"><code>v4.17.2</code></a></h3>
<p><a href="https://renovatebot.com/gh/webpack/webpack/compare/v4.17.1…v4.17.2">Compare Source</a></p>
<h3 id="bugfixes">Bugfixes</h3>
<ul>
<li>fix a spacing issue with the ProgressPlugin on some terminals</li>
<li>force-upgrade webpack-sources for performance improvement (was already in semver range)</li>
</ul>
<hr />
<h3 id="v4171httpsgithubcomwebpackwebpackreleasesv4171"><a href="https://renovatebot.com/gh/webpack/webpack/releases/v4.17.1"><code>v4.17.1</code></a></h3>
<p><a href="https://renovatebot.com/gh/webpack/webpack/compare/v4.17.0…v4.17.1">Compare Source</a></p>
<h3 id="bugfixes-1">Bugfixes</h3>
<ul>
<li>fix missing reexports in <code>export *</code> in a concatenated module</li>
</ul>
<hr />
<h3 id="v4170httpsgithubcomwebpackwebpackreleasesv4170"><a href="https://renovatebot.com/gh/webpack/webpack/releases/v4.17.0"><code>v4.17.0</code></a></h3>
<p><a href="https://renovatebot.com/gh/webpack/webpack/compare/v4.16.5…v4.17.0">Compare Source</a></p>
<h3 id="features">Features</h3>
<ul>
<li>allow to provide custom functions to IgnorePlugin</li>
</ul>
<h3 id="bugfixes-2">Bugfixes</h3>
<ul>
<li>remove incorrectly emitted dead code in concatenated modules</li>
<li>chunk ids contribute to <code>[contenthash]</code> for js assets</li>
<li>fix crash when trying to export globals in concatenated modules</li>
</ul>
<hr />
<h3 id="v4165httpsgithubcomwebpackwebpackreleasesv4165"><a href="https://renovatebot.com/gh/webpack/webpack/releases/v4.16.5"><code>v4.16.5</code></a></h3>
<p><a href="https://renovatebot.com/gh/webpack/webpack/compare/v4.16.4…v4.16.5">Compare Source</a></p>
<h3 id="bugfixes-3">Bugfixes</h3>
<ul>
<li>(resource) query now works in <code>import()</code></li>
<li>adding entries multiple times now overrides properly<ul>
<li>This caused an issue when using <code>webpack-hot-client</code> and runtime chunks</li></ul></li>
</ul>
<hr />
<h3 id="v4164httpsgithubcomwebpackwebpackreleasesv4164"><a href="https://renovatebot.com/gh/webpack/webpack/releases/v4.16.4"><code>v4.16.4</code></a></h3>
<p><a href="https://renovatebot.com/gh/webpack/webpack/compare/v4.16.3…v4.16.4">Compare Source</a></p>
<h3 id="bugfixes-4">Bugfixes</h3>
<ul>
<li>fix <code>chunkAsset</code> hook in HotModuleReplacementPlugin</li>
</ul>
<hr />
<h3 id="v4163httpsgithubcomwebpackwebpackreleasesv4163"><a href="https://renovatebot.com/gh/webpack/webpack/releases/v4.16.3"><code>v4.16.3</code></a></h3>
<p><a href="https://renovatebot.com/gh/webpack/webpack/compare/v4.16.2…v4.16.3">Compare Source</a></p>
<h3 id="bugfixes-5">Bugfixes</h3>
<ul>
<li>fix missing modules with chunks nested in unneeded <code>require.ensure</code>s.</li>
</ul>
<hr />
<h3 id="v4162httpsgithubcomwebpackwebpackreleasesv4162"><a href="https://renovatebot.com/gh/webpack/webpack/releases/v4.16.2"><code>v4.16.2</code></a></h3>
<p><a href="https://renovatebot.com/gh/webpack/webpack/compare/v4.16.1…v4.16.2">Compare Source</a></p>
<h3 id="bugfixes-6">Bugfixes</h3>
<ul>
<li>handle <code>module.require</code> like <code>require</code></li>
<li>emit warnings for <code>module.main.require</code> and <code>module.parent.require</code></li>
<li>sort reasons in stats</li>
<li>handle errors when parsing manifest in DllReferencePlugin</li>
</ul>
<hr />
<h3 id="v4161httpsgithubcomwebpackwebpackreleasesv4161"><a href="https://renovatebot.com/gh/webpack/webpack/releases/v4.16.1"><code>v4.16.1</code></a></h3>
<p><a href="https://renovatebot.com/gh/webpack/webpack/compare/v4.16.0…v4.16.1">Compare Source</a></p>
<h3 id="bugfixes-7">Bugfixes</h3>
<ul>
<li>fix reversed order when using optimization.occurrenceOrder (default in production mode)</li>
<li><code>output.hashDigest</code> has a more relaxed schema</li>
<li>update dependencies</li>
<li>fix typo in schema</li>
</ul>
<h3 id="internal-changes">Internal changes</h3>
<ul>
<li>typescript 3 rc</li>
</ul>
<hr />
<h3 id="v4160httpsgithubcomwebpackwebpackreleasesv4160"><a href="https://renovatebot.com/gh/webpack/webpack/releases/v4.16.0"><code>v4.16.0</code></a></h3>
<p><a href="https://renovatebot.com/gh/webpack/webpack/compare/v4.15.1…v4.16.0">Compare Source</a></p>
<h3 id="features-1">Features</h3>
<ul>
<li>add wasm support for <code>electron-renderer</code> target</li>
<li>add <code>optimization.moduleIds</code> and <code>optimization.chunkIds</code> options to replace other options</li>
</ul>
<h3 id="bugfixes-8">Bugfixes</h3>
<ul>
<li>fix order of side effect evaluation for exported dependencies in side-effect-free modules</li>
<li>fix some typos</li>
<li>Support the case when passing an array to <code>output.library.root</code> and using a devtool</li>
<li>fix a HMR logging message issue in browser where <code>err.stack</code> is not set</li>
<li>add missing default extensions to the DllReferencePlugin</li>
<li>module/chunk ids in Stats now sort numerical when they are numbers</li>
<li>fix lost chunk reasons when using <code>optimization.splitChunks.maxSize</code></li>
<li>fix cases where <code>Dependency.loc</code> is a string instead of an object</li>
</ul>
<h3 id="deprecations">Deprecations</h3>
<ul>
<li>deprecated <code>Dependency.compare</code> in favor of <code>compareLocations</code></li>
<li><code>optimization.namedModules</code> is now deprecated</li>
<li><code>optimization.hashedModuleIds</code> is now deprecated</li>
<li><code>optimization.namedChunks</code> is now deprecated</li>
<li><code>optimization.occurrenceOrder</code> is now deprecated</li>
</ul>
<hr />
<h3 id="v4151httpsgithubcomwebpackwebpackreleasesv4151"><a href="https://renovatebot.com/gh/webpack/webpack/releases/v4.15.1"><code>v4.15.1</code></a></h3>
<p><a href="https://renovatebot.com/gh/webpack/webpack/compare/v4.15.0…v4.15.1">Compare Source</a></p>
<h3 id="bugfixes-9">Bugfixes</h3>
<ul>
<li>fix memory leaks when using HMR and in SplitChunksPlugin cache</li>
<li>fix undefined automaticNameDelimiter in cache groups when using maxSize</li>
<li>fix ProfilingPlugin for node.js 10 and 6</li>
</ul>
<hr />
<h3 id="v4150httpsgithubcomwebpackwebpackreleasesv4150"><a href="https://renovatebot.com/gh/webpack/webpack/releases/v4.15.0"><code>v4.15.0</code></a></h3>
<p><a href="https://renovatebot.com/gh/webpack/webpack/compare/v4.14.0…v4.15.0">Compare Source</a></p>
<h3 id="features-2">Features:</h3>
<ul>
<li>add <code>maxSize</code> option for <code>splitChunks</code> (experimental)</li>
<li>add a helpful error when using wasm in a initial chunk</li>
</ul>
<hr />
<h3 id="v4140httpsgithubcomwebpackwebpackreleasesv4140"><a href="https://renovatebot.com/gh/webpack/webpack/releases/v4.14.0"><code>v4.14.0</code></a></h3>
<p><a href="https://renovatebot.com/gh/webpack/webpack/compare/v4.13.0…v4.14.0">Compare Source</a></p>
<h3 id="features-3">Features</h3>
<ul>
<li>add new hook <code>Compilation.dependencyReference</code> to modify the dependency references</li>
</ul>
<h3 id="bugfixes-10">Bugfixes</h3>
<ul>
<li>Allow chunks to emit multiple assets to the same filename when hash matches</li>
</ul>
<hr />
<h3 id="v4130httpsgithubcomwebpackwebpackreleasesv4130"><a href="https://renovatebot.com/gh/webpack/webpack/releases/v4.13.0"><code>v4.13.0</code></a></h3>
<p><a href="https://renovatebot.com/gh/webpack/webpack/compare/v4.12.2…v4.13.0">Compare Source</a></p>
<h3 id="features-4">Features</h3>
<ul>
<li>the <code>DefinePlugin</code> now supports <code>runtimeValue</code>s to pass computed values with dependencies that can change over time</li>
<li>added <code>optimization.hashedModuleIds</code></li>
<li>crossOrigin for chunks is only set when really needed</li>
<li>added per chunk group indicies</li>
<li>updated enhanced-resolve<ul>
<li>You can now use absolute paths as keys to <code>resolve.alias</code></li></ul></li>
</ul>
<h3 id="bugfixes-11">Bugfixes</h3>
<ul>
<li>when delegating CLI the <code>bin</code> fields are used</li>
<li>when assigning indicies sync dependencies are now walked before async dependencies</li>
</ul>
<hr />
<h3 id="v4122httpsgithubcomwebpackwebpackreleasesv4122"><a href="https://renovatebot.com/gh/webpack/webpack/releases/v4.12.2"><code>v4.12.2</code></a></h3>
<p><a href="https://renovatebot.com/gh/webpack/webpack/compare/v4.12.1…v4.12.2">Compare Source</a></p>
<h3 id="bugfixes-12">Bugfixes</h3>
<ul>
<li>fix crash when using invalid JSON with HMR</li>
<li>fix missing modules when a side-effect-free package is root of module concatenation</li>
<li>update chunkhash when entry-chunks list or prefetched chunks change</li>
</ul>
<hr />
<h3 id="v4121httpsgithubcomwebpackwebpackreleasesv4121"><a href="https://renovatebot.com/gh/webpack/webpack/releases/v4.12.1"><code>v4.12.1</code></a></h3>
<p><a href="https://renovatebot.com/gh/webpack/webpack/compare/v4.12.0…v4.12.1">Compare Source</a></p>
<h3 id="bugfixes-13">Bugfixes</h3>
<ul>
<li>fix problem causing a stack overflow when reexporting circular</li>
<li>fix a bug causing missing modules in bundles when using <code>splitChunks</code></li>
<li>run modules in correct order when using <code>import</code> with <code>sideEffects: false</code><ul>
<li>added order to <code>DependencyReference</code></li></ul></li>
<li>add missing support for <code>[chunkhash]</code> in <code>target: "webworker"</code></li>
<li>fix bug causing incomplete profile (race condition) with the <code>ProfilingPlugin</code></li>
</ul>
<h3 id="internal-changes-1">Internal changes</h3>
<ul>
<li>Added more types</li>
<li>lint files on commit with <code>lint-staged</code></li>
</ul>
<hr />
<h3 id="v4120httpsgithubcomwebpackwebpackreleasesv4120"><a href="https://renovatebot.com/gh/webpack/webpack/releases/v4.12.0"><code>v4.12.0</code></a></h3>
<p><a href="https://renovatebot.com/gh/webpack/webpack/compare/v4.11.1…v4.12.0">Compare Source</a></p>
<h3 id="features-5">Features</h3>
<ul>
<li>Errors from loaders show the loader path in the error message</li>
<li>add support for optional catch and line and paragraph separator in strings (ES2019)</li>
</ul>
<h3 id="bugfixes-14">Bugfixes</h3>
<ul>
<li>fixes a bug where chunks have duplicate ids when using records</li>
<li>fix bubbling in HMR for <code>import()</code> when importing a non-ESM</li>
<li>fix issue with in installing with pnpm</li>
<li>update dependencies of the ProfilingPlugin</li>
</ul>
<hr />
<h3 id="v4111httpsgithubcomwebpackwebpackreleasesv4111"><a href="https://renovatebot.com/gh/webpack/webpack/releases/v4.11.1"><code>v4.11.1</code></a></h3>
<p><a href="https://renovatebot.com/gh/webpack/webpack/compare/v4.11.0…v4.11.1">Compare Source</a></p>
<h3 id="features-6">Features</h3>
<ul>
<li>add <code>optimization.mangleWasmImports</code> option to disable mangling of wasm imports</li>
</ul>
<h3 id="bugfixes-15">Bugfixes</h3>
<ul>
<li>disable wasm import mangling temporary because of bugs in the underlying wasm processing</li>
</ul>
<hr />
<h3 id="v4110httpsgithubcomwebpackwebpackreleasesv4110"><a href="https://renovatebot.com/gh/webpack/webpack/releases/v4.11.0"><code>v4.11.0</code></a></h3>
<p><a href="https://renovatebot.com/gh/webpack/webpack/compare/v4.10.2…v4.11.0">Compare Source</a></p>
<h3 id="features-7">Features</h3>
<ul>
<li>support <code>reportProgress</code> in <code>afterEmit</code></li>
<li>Warnings are now emitted if magic comments don't compile</li>
<li>Added support for matchResource inline request for loaders</li>
<li>Using webpackPrefetch in entry chunk now triggers prefetching in runtime<ul>
<li>No link tag needed for this in HTML</li></ul></li>
<li>Warnings will be emitted when trying to use i64-functions imported from wasm</li>
</ul>
<h3 id="bugfixes-16">Bugfixes</h3>
<ul>
<li>get_global initializer in wasm globals now work correctly</li>
<li>Reexporting globals is now handled correctly</li>
<li>Error origins and locations are now displayed correctly</li>
</ul>
<hr />
<h3 id="v4102httpsgithubcomwebpackwebpackreleasesv4102"><a href="https://renovatebot.com/gh/webpack/webpack/releases/v4.10.2"><code>v4.10.2</code></a></h3>
<p><a href="https://renovatebot.com/gh/webpack/webpack/compare/v4.10.1…v4.10.2">Compare Source</a></p>
<h3 id="bugfixes-17">Bugfixes</h3>
<ul>
<li>order of wasm globals is correctly preversed while rewriting</li>
<li>skipping side-effect-free modules up to a concatenated modules will not longer cause <code>null</code> module ids</li>
</ul>
<hr />
<h3 id="v4101httpsgithubcomwebpackwebpackreleasesv4101"><a href="https://renovatebot.com/gh/webpack/webpack/releases/v4.10.1"><code>v4.10.1</code></a></h3>
<p><a href="https://renovatebot.com/gh/webpack/webpack/compare/v4.10.0…v4.10.1">Compare Source</a></p>
<h3 id="bugfixes-18">Bugfixes</h3>
<ul>
<li>update reasons correctly when skipping side-effect-free modules</li>
</ul>
<hr />
<h3 id="v4100httpsgithubcomwebpackwebpackreleasesv4100"><a href="https://renovatebot.com/gh/webpack/webpack/releases/v4.10.0"><code>v4.10.0</code></a></h3>
<p><a href="https://renovatebot.com/gh/webpack/webpack/compare/v4.9.2…v4.10.0">Compare Source</a></p>
<h3 id="features-8">Features</h3>
<ul>
<li>Export and import name strings in them wasm are mangled</li>
<li>Unused exports in wasm are removed (Tree Shaking)<ul>
<li>Don't expect size improvements yet since there is not minimizer for WASM yet which does the Dead Code Elimination, which is the second part for this optimization</li></ul></li>
<li>Direct WASM dependencies are enforced for:<ul>
<li>functions imports with i64 parameters or return values</li>
<li>memory and table imports</li></ul></li>
<li>generate shorter wasm runtime code</li>
<li>ESM namespace object now have <code>Symbol.toStringTag</code> <code>"Module"</code></li>
</ul>
<h3 id="bugfixes-19">Bugfixes</h3>
<ul>
<li>generate correct initializer for imported globals in wasm</li>
<li>side-effect-free modules referenced by <code>export * from</code> are no longer including in the bundle</li>
<li>the side-effects optimization is now possible in incremental compilation</li>
</ul>
<hr />
<h3 id="v492httpsgithubcomwebpackwebpackreleasesv492"><a href="https://renovatebot.com/gh/webpack/webpack/releases/v4.9.2"><code>v4.9.2</code></a></h3>
<p><a href="https://renovatebot.com/gh/webpack/webpack/compare/v4.9.1…v4.9.2">Compare Source</a></p>
<h3 id="bugfixes-20">Bugfixes</h3>
<ul>
<li>functions is defined because used (fixes undeclared function error in firefox)</li>
<li>progress plugin works now in MultiCompiler scenarios again</li>
</ul>
<hr />
<h3 id="v491httpsgithubcomwebpackwebpackreleasesv491"><a href="https://renovatebot.com/gh/webpack/webpack/releases/v4.9.1"><code>v4.9.1</code></a></h3>
<p><a href="https://renovatebot.com/gh/webpack/webpack/compare/v4.9.0…v4.9.1">Compare Source</a></p>
<h3 id="bugfixes-21">Bugfixes</h3>
<ul>
<li>fix parameter references in default parameters</li>
</ul>
<h3 id="internal-changes-2">Internal changes</h3>
<ul>
<li>change test cases to text format</li>
</ul>
<hr />
<h3 id="v490httpsgithubcomwebpackwebpackreleasesv490"><a href="https://renovatebot.com/gh/webpack/webpack/releases/v4.9.0"><code>v4.9.0</code></a></h3>
<p><a href="https://renovatebot.com/gh/webpack/webpack/compare/v4.8.3…v4.9.0">Compare Source</a></p>
<h3 id="features-9">Features</h3>
<ul>
<li><code>BannerPlugin</code> supports a function as <code>banner</code> option</li>
<li>allow <code>serve</code> property in configuration schema</li>
<li>add <code>entryOnly</code> option to <code>DllPlugin</code> to only expose modules in the entry point</li>
<li>Allow to choose between <code>webpack-cli</code> and <code>webpack-command</code></li>
<li>improve error message when JSON parsing fails</li>
<li>allow BOM in JSON</li>
<li>sort <code>usedIds</code> in <code>records</code> for stablility</li>
</ul>
<h3 id="bugfixes-22">Bugfixes</h3>
<ul>
<li>align module not found error message with node.js</li>
<li>fix behavior of <code>splitChunks</code> when request limit has reached (caused suboptimal splitting)</li>
<li>fix handling of RegExp in records (caused absolute path in records)</li>
<li>fix handling of circular chunks (caused missing <code>__webpack_require__.e</code>)</li>
<li><code>runtimeChunk</code> is even generated when all modules are moved by <code>splitChunks</code> (caused multiple runtime chunks instead of single one)</li>
<li>string ids are no longer recorded (caused duplicate/wrong chunk ids)</li>
<li>fix link to migration guide in error message</li>
</ul>
<h3 id="internal-changes-3">Internal changes</h3>
<ul>
<li>add more typings</li>
<li>Use travis stages</li>
<li>add <code>many-pages</code> example</li>
</ul>
<hr />
<h3 id="v483httpsgithubcomwebpackwebpackreleasesv483"><a href="https://renovatebot.com/gh/webpack/webpack/releases/v4.8.3"><code>v4.8.3</code></a></h3>
<p><a href="https://renovatebot.com/gh/webpack/webpack/compare/v4.8.2…v4.8.3">Compare Source</a></p>
<h3 id="bugfixes-23">Bugfixes</h3>
<ul>
<li>fix missing <code>debug</code> dependency</li>
<li>support arrays in <code>output.library.root</code></li>
</ul>
<hr />
<h3 id="v482httpsgithubcomwebpackwebpackreleasesv482"><a href="https://renovatebot.com/gh/webpack/webpack/releases/v4.8.2"><code>v4.8.2</code></a></h3>
<p><a href="https://renovatebot.com/gh/webpack/webpack/compare/v4.8.1…v4.8.2">Compare Source</a></p>
<h3 id="bugfixes-24">Bugfixes</h3>
<ul>
<li>WASM parser bugfixes</li>
<li>fix edge case when replacing top-level this in IIFE</li>
<li>avoid parser wasm many times</li>
</ul>
<hr />
<h3 id="v481httpsgithubcomwebpackwebpackreleasesv481"><a href="https://renovatebot.com/gh/webpack/webpack/releases/v4.8.1"><code>v4.8.1</code></a></h3>
<p><a href="https://renovatebot.com/gh/webpack/webpack/compare/v4.8.0…v4.8.1">Compare Source</a></p>
<h3 id="bugfixes-25">Bugfixes</h3>
<ul>
<li>fix some WASM parsing issues</li>
</ul>
<hr />
<h3 id="v480httpsgithubcomwebpackwebpackreleasesv480"><a href="https://renovatebot.com/gh/webpack/webpack/releases/v4.8.0"><code>v4.8.0</code></a></h3>
<p><a href="https://renovatebot.com/gh/webpack/webpack/compare/v4.7.0…v4.8.0">Compare Source</a></p>
<h3 id="features-10">Features</h3>
<ul>
<li>new WASM pipeline<ul>
<li>use <code>instantiateStreaming</code> when available</li>
<li>allow circular dependencies between wasm modules (functions only)</li></ul></li>
</ul>
<h3 id="bugfixes-26">Bugfixes</h3>
<ul>
<li>fix a bug where runtime code for wasm was incorrectly cached</li>
<li>fix a bug where a splitChunks cacheGroup without name wasn't executed</li>
</ul>
<hr />
<h3 id="v470httpsgithubcomwebpackwebpackreleasesv470"><a href="https://renovatebot.com/gh/webpack/webpack/releases/v4.7.0"><code>v4.7.0</code></a></h3>
<p><a href="https://renovatebot.com/gh/webpack/webpack/compare/v4.6.0…v4.7.0">Compare Source</a></p>
<h3 id="features-11">Features</h3>
<ul>
<li>add webpackIgnore magic comment (<code>import(/* webpackIgnore: true */ "...")</code>) to keep the import in the bundle</li>
<li>add chunkGroups to Stats<ul>
<li><code>chunkGroups</code> option</li>
<li><code>namedChunkGroups</code> property</li>
<li><code>Chunk Group</code> text output</li></ul></li>
</ul>
<h3 id="bugfixes-27">Bugfixes</h3>
<ul>
<li>prevent chunk merging for the runtimeChunk</li>
<li>fix a caching issue for concatenated modules</li>
<li>namedModules now handle name conflicts correctly</li>
<li>fix a crash when using <code>[contenthash:n]</code> without on-demand-chunks</li>
</ul>
<h3 id="internal-changes-4">Internal changes</h3>
<ul>
<li>testing uses Jest now</li>
<li>testing in node.js 10 too</li>
<li>Performance improvements</li>
</ul>
<hr />
<h3 id="v460httpsgithubcomwebpackwebpackreleasesv460"><a href="https://renovatebot.com/gh/webpack/webpack/releases/v4.6.0"><code>v4.6.0</code></a></h3>
<p><a href="https://renovatebot.com/gh/webpack/webpack/compare/v4.5.0…v4.6.0">Compare Source</a></p>
<h3 id="features-12">Features</h3>
<ul>
<li>improve stats output alignment</li>
<li>improve stats text output when all exports are used</li>
<li>add <code>webpackPrefetch</code>/<code>webpackPreload</code> magic comments to <code>import()</code></li>
<li>add <code>stats.entrypoints[].children</code> and <code>stats.entrypoints[].childAssets</code> to stats json</li>
<li>add prefetched/preloaded chunks and assets to stats text output</li>
<li>Performance improvements</li>
</ul>
<h3 id="bugfixes-28">Bugfixes</h3>
<ul>
<li>Escape chunk ids for <code>target: "webworker"</code></li>
<li>fix <code>this</code> to <code>undefined</code> ESM replacement in function default values</li>
<li><code>new require(...)</code> is weird, but now behaves like in node.js</li>
<li>fix behavior of <code>export * from "commonjs"</code> with partial override</li>
<li>fixed build time output in current locale in stats text output</li>
<li>fixed ChunkModuleIdRangePlugin and add tests</li>
<li>avoid race condition when using the loadModule loader API</li>
<li>fix default value of <code>output.globalObject</code> in <code>target: "node-webkit"</code></li>
<li>fix a bug with <code>loadModules</code> and dependencies in these modules</li>
<li>fix hot.accept parser plugin to allow defined values as argument</li>
<li>print <code>unknown size</code> when size is unknown</li>
<li>fix a bug where some chunks were missing in the "single" runtime chunk</li>
<li>fix cloning of <code>optimization</code> configuration</li>
</ul>
<h3 id="internal-changes-5">Internal changes</h3>
<ul>
<li>Set up infrastructure for linting typings with TypeScript</li>
</ul>
<hr />
<h3 id="v450httpsgithubcomwebpackwebpackreleasesv450"><a href="https://renovatebot.com/gh/webpack/webpack/releases/v4.5.0"><code>v4.5.0</code></a></h3>
<p><a href="https://renovatebot.com/gh/webpack/webpack/compare/v4.4.1…v4.5.0">Compare Source</a></p>
<h3 id="features-13">Features</h3>
<ul>
<li>Performance improvements</li>
<li>Improve readablility of error messages with long loader string</li>
</ul>
<h3 id="bugfixes-29">Bugfixes</h3>
<ul>
<li>Sort child compilations for consistent compilation hash</li>
<li>Fix bug causing all symbols to be renamed when concatenating modules</li>
</ul>
<h3 id="contributing">Contributing</h3>
<ul>
<li>add <code>yarn setup</code> script for bootstrapping local development</li>
</ul>
<hr />
<h3 id="v441httpsgithubcomwebpackwebpackreleasesv441"><a href="https://renovatebot.com/gh/webpack/webpack/releases/v4.4.1"><code>v4.4.1</code></a></h3>
<p><a href="https://renovatebot.com/gh/webpack/webpack/compare/v4.4.0…v4.4.1">Compare Source</a></p>
<h3 id="bugfixes-30">Bugfixes</h3>
<ul>
<li>fix yarn/npm install script on windows</li>
</ul>
<hr />
<h3 id="v440httpsgithubcomwebpackwebpackreleasesv440"><a href="https://renovatebot.com/gh/webpack/webpack/releases/v4.4.0"><code>v4.4.0</code></a></h3>
<p><a href="https://renovatebot.com/gh/webpack/webpack/compare/v4.3.0…v4.4.0">Compare Source</a></p>
<h3 id="features-14">Features</h3>
<ul>
<li>When webpack-cli is not installed it will ask to install it</li>
<li><code>splitChunks.chunks</code> supports a custom function now</li>
<li>Better warning when omitting <code>mode</code></li>
</ul>
<h3 id="bugfixes-31">Bugfixes</h3>
<ul>
<li>disallow functions for <code>chunkFilename</code>, because it's not working</li>
<li>generate correct code when using <code>export default (function xxx() {})</code></li>
</ul>
<h3 id="performance">Performance</h3>
<ul>
<li>Performance improvements for sorting by identifier</li>
</ul>
<hr />
<h3 id="v430httpsgithubcomwebpackwebpackreleasesv430"><a href="https://renovatebot.com/gh/webpack/webpack/releases/v4.3.0"><code>v4.3.0</code></a></h3>
<p><a href="https://renovatebot.com/gh/webpack/webpack/compare/v4.2.0…v4.3.0">Compare Source</a></p>
<h3 id="features-15">Features</h3>
<ul>
<li>add support for <code>[contenthash]</code> placeholder</li>
</ul>
<h3 id="bugfixes-32">Bugfixes</h3>
<ul>
<li><code>browser</code> field is used for target <code>electron-renderer</code></li>
<li>set <code>devtoolNamespace</code> default correctly when passing an object to <code>output.library</code></li>
</ul>
<hr />
<h3 id="v420httpsgithubcomwebpackwebpackreleasesv420"><a href="https://renovatebot.com/gh/webpack/webpack/releases/v4.2.0"><code>v4.2.0</code></a></h3>
<p><a href="https://renovatebot.com/gh/webpack/webpack/compare/v4.1.1…v4.2.0">Compare Source</a></p>
<h3 id="features-16">Features</h3>
<ul>
<li>add <code>splitChunks.automaticNameDelimiter</code> to configure the name separator for automatic names</li>
<li><code>stats.excludeModules</code> now also accept booleans</li>
<li>webpack throws an error when trying to run in twice at a time</li>
<li><code>performance</code> is disabled by default in non-web targets</li>
<li>AMD parser plugins can now be extended by inheriting</li>
</ul>
<h3 id="bugfixes-33">Bugfixes</h3>
<ul>
<li>Fix a race condition when writing <code>events.json</code> in ProfilingPlugin</li>
<li>HMR runtime code is reverted to ES5 style</li>
<li>script timeout is not correctly in seconds</li>
<li>reexporting JSON exports works correctly now</li>
<li>fix a bug when combining ProfilingPlugin with SourceMapDevToolPlugin</li>
<li>add a missing semicolon to the runtime code</li>
</ul>
<hr />
<h3 id="v411httpsgithubcomwebpackwebpackreleasesv411"><a href="https://renovatebot.com/gh/webpack/webpack/releases/v4.1.1"><code>v4.1.1</code></a></h3>
<p><a href="https://renovatebot.com/gh/webpack/webpack/compare/v4.1.0…v4.1.1">Compare Source</a></p>
<h3 id="features-17">Features</h3>
<ul>
<li>Stats now displays the number of assets of a module</li>
</ul>
<h3 id="bugfixes-34">Bugfixes</h3>
<ul>
<li><code>sourceMap</code> option of the default UglifyJsPlugin now defaults to true when the SourceMapDevToolPlugin is used</li>
<li><code>module.assets</code> is now working again in the Stats</li>
<li>chunk ids are not stringified on target node</li>
<li><code>devtoolNamespace</code> default works now also for arrays passed to <code>output.library</code></li>
<li>Format date with 2 digits in Stats for Build At </li>
<li>fix a bug renaming classes incorrectly</li>
<li>fix a bug where modules ignore the <code>chunks</code> option of <code>optimization.splitChunks</code></li>
</ul>
<hr />
<h3 id="v410httpsgithubcomwebpackwebpackreleasesv410"><a href="https://renovatebot.com/gh/webpack/webpack/releases/v4.1.0"><code>v4.1.0</code></a></h3>
<p><a href="https://renovatebot.com/gh/webpack/webpack/compare/v4.0.1…v4.1.0">Compare Source</a></p>
<h3 id="features-18">Features</h3>
<ul>
<li>add <code>filename</code> option to <code>optimization.splitChunks</code> to modify the filename template for splitted chunks</li>
<li>allow modules which doesn't emit code into the bundle</li>
</ul>
<h3 id="bugfixes-35">Bugfixes</h3>
<ul>
<li>watchpack updated to 1.5.0</li>
<li>performance fix for Module Concatenation (v8 bug)</li>
<li>fix using <code>this.xxx</code> in <code>ProvidePlugin</code></li>
</ul>
<hr />
<h3 id="v401httpsgithubcomwebpackwebpackreleasesv401"><a href="https://renovatebot.com/gh/webpack/webpack/releases/v4.0.1"><code>v4.0.1</code></a></h3>
<p><a href="https://renovatebot.com/gh/webpack/webpack/compare/v4.0.0…v4.0.1">Compare Source</a></p>
<h3 id="features-19">Features</h3>
<ul>
<li>add <code>version</code> property to webpack exports</li>
</ul>
<h3 id="bugfixes-36">Bugfixes</h3>
<ul>
<li><code>import()</code> with CJS now gives correct exports</li>
<li>Module concatenation bailout messages now point to correct module</li>
</ul>
<hr />
<h3 id="v400httpsgithubcomwebpackwebpackreleasesv400"><a href="https://renovatebot.com/gh/webpack/webpack/releases/v4.0.0"><code>v4.0.0</code></a></h3>
<p><a href="https://renovatebot.com/gh/webpack/webpack/compare/v3.12.0…v4.0.0">Compare Source</a></p>
<h3 id="big-changes">Big changes</h3>
<ul>
<li>Environment<ul>
<li>Node.js 4 is no longer supported. Source Code was upgraded to a higher ecmascript version.</li></ul></li>
<li>Usage<ul>
<li>You have to choose (<code>mode</code> or <code>--mode</code>) between two modes now: production or development<ul>
<li>production enables all kind of optimizations to generate optimized bundles</li>
<li>development enables comments and hint for development and enables the eval devtool</li>
<li>production doesn't support watching, development is optimized for fast incremental rebuilds</li>
<li>production also enables module concatenating (Scope Hoisting)</li>
<li>You can configure this in detail with the flags in <code>optimization.*</code> (build your custom mode)</li>
<li><code>process.env.NODE_ENV</code> are set to production or development (only in built code, not in config)</li>
<li>There is a hidden <code>none</code> mode which disables everything</li></ul></li></ul></li>
<li>Syntax<ul>
<li><code>import()</code> always returns a namespace object. CommonJS modules are wrapped into the default export<ul>
<li>This probably breaks your code, if you used to import CommonJs with <code>import()</code></li></ul></li></ul></li>
<li>Configuration<ul>
<li>You no longer need to use these plugins:<ul>
<li><code>NoEmitOnErrorsPlugin</code> -&gt; <code>optimization.noEmitOnErrors</code> (on by default in production mode)</li>
<li><code>ModuleConcatenationPlugin</code> -&gt; <code>optimization.concatenateModules</code> (on by default in production mode)</li>
<li><code>NamedModulesPlugin</code> -&gt; <code>optimization.namedModules</code> (on by default in develoment mode)</li></ul></li>
<li><code>CommonsChunkPlugin</code> was removed -&gt; <code>optimization.splitChunks</code>, <code>optimization.runtimeChunk</code></li></ul></li>
<li>JSON<ul>
<li>webpack now handles JSON natively<ul>
<li>You may need to add <code>type: "javascript/auto"</code> when transforming JSON via loader to JS</li>
<li>Just using JSON without loader should still work</li></ul></li>
<li>allows to import JSON via ESM syntax<ul>
<li>unused exports elimination for JSON modules</li></ul></li></ul></li>
<li>Optimization<ul>
<li>Upgrade uglifyjs-webpack-plugin to v1<ul>
<li>ES15 support</li></ul></li></ul></li>
</ul>
<h3 id="big-features">Big features</h3>
<ul>
<li>Modules<ul>
<li>webpack now supports these module types:<ul>
<li>javascript/auto: (The default one in webpack 3) Javascript module with all module systems enabled: CommonJS, AMD, ESM</li>
<li>javascript/esm: EcmaScript modules, all other module system are not available</li>
<li>javascript/dynamic: Only CommonJS and, EcmaScript modules are not available</li>
<li>json: JSON data, it's available via require and import</li>
<li>webassembly/experimental: WebAssembly modules (currently experimental)</li></ul></li>
<li><code>javascript/esm</code> handles ESM more strictly compared to <code>javascript/auto</code>:<ul>
<li>Imported names need to exist on imported module</li>
<li>Dynamic modules (non-esm, i. e. CommonJs) can only imported via <code>default</code> import, everything else (including namespace import) emit errors</li></ul></li>
<li>In <code>.mjs</code> modules are <code>javascript/esm</code> by default</li>
<li>WebAssembly modules<ul>
<li>can import other modules (JS and WASM)</li>
<li>Exports from WebAssembly modules are validated by ESM import<ul>
<li>You'll get a warning/error when trying to import a non-existing export from WASM</li></ul></li>
<li>can only be used in async chunks. They doesn't work in initial chunks (would be bad for web performance)<ul>
<li>Import modules using WASM via <code>import()</code></li></ul></li>
<li>This is an experimental feature and subject of change</li></ul></li></ul></li>
<li>Optimization<ul>
<li><code>sideEffects: false</code> is now supported in package.json<ul>
<li><code>sideEffects</code> in package.json also supports glob expressions and arrays of glob expressions</li></ul></li>
<li>Instead of a JSONP function a JSONP array is used -&gt; async script tag support, order no longer matter</li>
<li>New <code>optimization.splitChunks</code> option was introduced<br />
Details: <a href="https://gist.github.com/sokra/1522d586b8e5c0f5072d7565c2bee693">https://gist.github.com/sokra/1522d586b8e5c0f5072d7565c2bee693</a></li>
<li>Dead branches are now removed by webpack itself<ul>
<li>Before: Uglify removed the dead code</li>
<li>Now: webpack removes the dead code (in some cases)</li>
<li>This prevents crashing when <code>import()</code> occur in a dead branch</li></ul></li></ul></li>
<li>Syntax<ul>
<li><code>webpackInclude</code> and <code>webpackExclude</code> are supported by the magic comment for <code>import()</code>. They allow to filter files when using a dynamic expression.</li>
<li>Using <code>System.import()</code> now emits a warning<ul>
<li>You can disable the warning with <code>Rule.parser.system: true</code></li>
<li>You can disable <code>System.import</code> with <code>Rule.parser.system: false</code></li></ul></li></ul></li>
<li>Configuration<ul>
<li>Resolving can now be configured with <code>module.rules[].resolve</code>. It's merged with the global configuration.</li>
<li><code>optimization.minimize</code> has been added to switch minimizing on/off<ul>
<li>By default: on in production mode, off in development mode</li></ul></li>
<li><code>optimization.minimizer</code> has been added to configurate minimizers and options</li></ul></li>
<li>Usage<ul>
<li>Some Plugin options are now validated</li>
<li>CLI has been move to webpack-cli, you need to install <code>webpack-cli</code> to use the CLI</li>
<li>The ProgressPlugin (<code>--progress</code>) now displays plugin names<ul>
<li>At least for plugins migrated to the new plugin system</li></ul></li></ul></li>
<li>Performance<ul>
<li>UglifyJs now caches and parallizes by default</li>
<li>Multiple performance improvements, especially for faster incremental rebuilds</li>
<li>performance improvement for RemoveParentModulesPlugin</li></ul></li>
<li>Stats<ul>
<li>Stats can display modules nested in concatenated modules</li></ul></li>
</ul>
<h3 id="features-20">Features</h3>
<ul>
<li>Configuration<ul>
<li>Module type is automatically choosen for mjs, json and wasm extensions. Other extensions need to be configured via <code>module.rules[].type</code></li>
<li>Incorrect <code>options.dependencies</code> configurations now throw error</li>
<li><code>sideEffects</code> can be overriden via module.rules</li>
<li><code>output.hashFunction</code> can now be a Constructor to a custom hash function<ul>
<li>You can provide a non-cryto hash function for performance reasons</li></ul></li>
<li>add <code>output.globalObject</code> config option to allow to choose the global object reference in runtime exitCode</li></ul></li>
<li>Runtime<ul>
<li>Error for chunk loading now includes more information and two new properties <code>type</code> and <code>request</code>.</li></ul></li>
<li>Devtool<ul>
<li>remove comment footer from SourceMaps and eval</li>
<li>add support for <code>include</code> <code>test</code> and <code>exclude</code> to the eval source map devtool plugin</li></ul></li>
<li>Performance<ul>
<li>webpacks AST can be passed directly from loader to webpack to avoid extra parsing</li>
<li>Unused modules are no longer unnecessarly concatenated</li>
<li>Add a ProfilingPlugin which write a (Chrome) profile file which includes timings of plugins</li>
<li>Migrate to using <code>for of</code> instead of <code>forEach</code></li>
<li>Migrate to using <code>Map</code> and <code>Set</code> instead of Objects</li>
<li>Migrate to using <code>includes</code> instead of <code>indexOf</code></li>
<li>Replaced some RegExp with string methods</li>
<li>Queue don't enqueues the same job twice</li>
<li>Use faster md4 hash for hashing by default</li></ul></li>
<li>Optimization<ul>
<li>When using more than 25 exports mangled export names are shorter.</li>
<li>script tags are no longer <code>text/javascript</code> and <code>async</code> as this are the default values (saves a few bytes)</li>
<li>The concatenated module now generates a bit less code</li>
<li>constant replacements now don't need <code>__webpack_require__</code> and argument is omitted</li></ul></li>
<li>Defaults<ul>
<li>webpack now looks for the <code>.wasm</code>, <code>.mjs</code>, <code>.js</code> and <code>.json</code> extensions in this order</li>
<li><code>output.pathinfo</code> is now on by default in develoment mode</li>
<li>in-memory caching is now off by default in production</li>
<li><code>entry</code> defaults to <code>./src</code></li>
<li><code>output.path</code> defaults to <code>./dist</code></li>
<li>Use <code>production</code> defaults when omiting the <code>mode</code> option</li></ul></li>
<li>Usage<ul>
<li>Add detailed progress reporting to SourceMapDevToolPlugin</li>
<li>removed plugins now give a useful error message</li></ul></li>
<li>Stats<ul>
<li>Sizes are now shown in kiB instead of kB in Stats</li>
<li>entrypoints are now shows by default in Stats</li>
<li>chunks now display <code>&lt;{parents}&gt;</code> <code>&gt;{children}&lt;</code> and <code>={siblings}=</code> in Stats</li>
<li>add <code>buildAt</code> time to stats</li>
<li>stats json now includes the output path</li></ul></li>
<li>Syntax<ul>
<li>A resource query is supported in context</li>
<li>Referencing entry point name in <code>import()</code> now emits a error instead of a warning</li>
<li>Upgraded to acorn 5 and support ES 2018</li></ul></li>
<li>Plugins<ul>
<li><code>done</code> is now an async hook</li></ul></li>
</ul>
<h3 id="bugfixes-37">Bugfixes</h3>
<ul>
<li>Generated comments no longer break on <code>*/</code></li>
<li>webpack no longer modifies the passed options object</li>
<li>Compiler "watch-run" hook now has the Compiler as first parameter</li>
<li>add <code>output.chunkCallbackName</code> to the schema to allow configurating WebWorker template</li>
<li>Using <code>module.id/loaded</code> now correctly bails out of Module Concatentation (Scope Hoisting)</li>
<li>OccurenceOrderPlugin now sorts modules in correct order (instead of reversed)</li>
<li>timestamps for files are read from watcher when calling <code>Watching.invalidate</code></li>
<li>fix incorrect <code>-!</code> behavior with post loaders</li>
<li>add <code>run</code> and <code>watchRun</code> hooks for <code>MultiCompiler</code></li>
<li><code>this</code> is now undefined in ESM</li>
<li>VariableDeclaration are correctly identified as <code>var</code>, <code>const</code> or <code>let</code></li>
<li>Parser now parse the source code with the correct source type (module/script) when the module type <code>javascript/dynamic</code> or <code>javascript/module</code> is used.</li>
<li>don't crash on missing modules with <code>buildMeta</code> of null</li>
<li>add <code>original-fs</code> module for electron targets</li>
<li>HMRPlugin can be added to the Compiler outside of <code>plugins</code></li>
</ul>
<h3 id="internal-changes-6">Internal changes</h3>
<ul>
<li>Replaced <code>plugin</code> calls with <code>tap</code> calls (new plugin system)</li>
<li>Migrated many deprecated plugins to new plugin system API</li>
<li>added <code>buildMeta.exportsType: "default"</code> for json modules</li>
<li>Remove unused methods from Parser (parserStringArray, parserCalculatedStringArray)</li>
<li>Remove ability to clear BasicEvaluatedExpression and to have multiple types</li>
<li>Buffer.from instead of new Buffer</li>
<li>Avoid using forEach and use for of instead</li>
<li>Use <code>neo-async</code> instead of <code>async</code></li>
<li>Update tapable and enhanced-resolve dependencies to new major versions</li>
<li>Use prettier</li>
</ul>
<h3 id="removed-features">Removed features</h3>
<ul>
<li>removed <code>module.loaders</code></li>
<li>removed <code>loaderContext.options</code></li>
<li>removed <code>Compilation.notCacheable</code> flag</li>
<li>removed <code>NoErrorsPlugin</code></li>
<li>removed <code>Dependency.isEqualResource</code></li>
<li>removed <code>NewWatchingPlugin</code></li>
<li>removed <code>CommonsChunkPlugin</code></li>
</ul>
<h3 id="breaking-changes-for-pluginsloaders">Breaking changes for plugins/loaders</h3>
<ul>
<li>new plugin system<ul>
<li><code>plugin</code> method is backward-compatible</li>
<li>Plugins should use <code>Compiler.hooks.xxx.tap(&lt;plugin name&gt;, fn)</code> now</li></ul></li>
<li>New major version of enhanced-resolve</li>
<li>Templates for chunks may now generate multiple assets</li>
<li><code>Chunk.chunks/parents/blocks</code> are no longer Arrays. A Set is used internally and there are methods to access it.</li>
<li><code>Parser.scope.renames</code> and <code>Parser.scope.definitions</code> are no longer Objects/Arrays, but Map/Sets.</li>
<li>Parser uses <code>StackedSetMap</code> (LevelDB-like datastructure) instead of Arrays</li>
<li><code>Compiler.options</code> is no longer set while applying plugins</li>
<li>Harmony Dependencies has changed because of refactoring</li>
<li><code>Dependency.getReference()</code> may now return a <code>weak</code> property. <code>Dependency.weak</code> is now used by the <code>Dependency</code> base class and returned in the base impl of <code>getReference()</code></li>
<li>Constructor arguments changed for all <code>Module</code>s</li>
<li>Merged options into options object for <code>ContextModule</code> and <code>resolveDependencies</code></li>
<li>Changed and renamed dependencies for `import()</li>
<li>Moved <code>Compiler.resolvers</code> into <code>Compiler.resolverFactory</code> accessible with plugins</li>
<li><code>Dependency.isEqualResource</code> has been replaced with <code>Dependency.getResourceIdentifier</code></li>
<li>Methods on <code>Template</code> are now static</li>
<li>A new RuntimeTemplate class has been added and <code>outputOptions</code> and <code>requestShortener</code> has been moved to this class<ul>
<li>Many methods has been updated to use the RuntimeTemplate instead</li>
<li>We plan to move code which accesses the runtime to this new class</li></ul></li>
<li><code>Module.meta</code> has been replaced with <code>Module.buildMeta</code></li>
<li><code>Module.buildInfo</code> and <code>Module.factoryMeta</code> have been added</li>
<li>Some properties of <code>Module</code> have been moved into the new objects</li>
<li>added <code>loaderContext.rootContext</code> which points to the <code>context</code> options. Loaders may use it to make stuff relative to the application root.</li>
<li>add <code>this.hot</code> flag to loader context when HMR is enabled</li>
<li><code>buildMeta.harmony</code> has been replaced with <code>buildMeta.exportsType: "namespace</code></li>
<li>The chunk graph has changed:<ul>
<li>Before: Chunks were connected with parent-child-relationships.</li>
<li>Now: ChunkGroups are connected with parent-child-relationships. ChunkGroups contain Chunks in order.</li>
<li>Before: AsyncDependenciesBlocks reference a list of Chunks in order.</li>
<li>Now: AsyncDependenciesBlocks reference a single ChunkGroup.</li></ul></li>
<li>file/contextTimestamps are Maps now</li>
<li><code>map/foreach</code> <code>Chunks/Modules/Parents</code> methods are now deprecated/removed</li>
<li>NormalModule accept options object in Constructor</li>
<li>Added required generator argument for NormalModule</li>
<li>Added <code>createGenerator</code> and <code>generator</code> hooks for NormalModuleFactory to customize code generation</li>
<li>Allow to customize render manifest for Chunks via hooks</li>
</ul>
<hr />
<h3 id="v3120httpsgithubcomwebpackwebpackreleasesv3120"><a href="https://renovatebot.com/gh/webpack/webpack/releases/v3.12.0"><code>v3.12.0</code></a></h3>
<p><a href="https://renovatebot.com/gh/webpack/webpack/compare/v3.11.0…v3.12.0">Compare Source</a></p>
<h3 id="bugfixes-38">Bugfixes</h3>
<ul>
<li>Sort modules by index by default</li>
<li>fix <code>hot.accept</code> creating duplicates when using the DefinePlugin</li>
</ul>
<hr />
<h3 id="v3110httpsgithubcomwebpackwebpackreleasesv3110"><a href="https://renovatebot.com/gh/webpack/webpack/releases/v3.11.0"><code>v3.11.0</code></a></h3>
<p><a href="https://renovatebot.com/gh/webpack/webpack/compare/v3.10.0…v3.11.0">Compare Source</a></p>
<h3 id="features-21">Features</h3>
<ul>
<li>Parser supports <code>new Foo</code> expressions</li>
<li>Evaluator supports bitwise and exponential operator</li>
<li>Many config options supporting placeholder now also support functions</li>
<li>add <code>jsonpScriptType</code> to specify script type for lazy loaded script tags</li>
<li>update ajv</li>
</ul>
<h3 id="bugfixes-39">Bugfixes</h3>
<ul>
<li>allow <code>ident</code> in schema</li>
<li><code>ident</code> is not lost when referencing by ident</li>
<li>Prefer <code>process.exitCode</code> instead of <code>process.exit</code></li>
<li>workaround for bluebird warning in hot/signal</li>
<li>Errors in child compilation now lead to global error</li>
<li>Initial chunk are no longer part of the chunk manifest and no longer contribute to the hash</li>
<li>don't crash on arrays with empty items</li>
<li>workaround for node 8 and 9 bug while reading empty env values</li>
</ul>
<hr />
<h3 id="v3100httpsgithubcomwebpackwebpackreleasesv3100"><a href="https://renovatebot.com/gh/webpack/webpack/releases/v3.10.0"><code>v3.10.0</code></a></h3>
<p><a href="https://renovatebot.com/gh/webpack/webpack/compare/v3.9.1…v3.10.0">Compare Source</a></p>
<h3 id="features-22">Features:</h3>
<ul>
<li>add <code>publicPath</code> and <code>fileContext</code> to SourceMapDevToolPlugin</li>
<li><code>require.include</code> no longer uses all exports (Tree Shaking)</li>
</ul>
<hr />
<h3 id="v391httpsgithubcomwebpackwebpackreleasesv391"><a href="https://renovatebot.com/gh/webpack/webpack/releases/v3.9.1"><code>v3.9.1</code></a></h3>
<p><a href="https://renovatebot.com/gh/webpack/webpack/compare/v3.9.0…v3.9.1">Compare Source</a></p>
<h3 id="bugfixes-40">Bugfixes:</h3>
<ul>
<li>add <code>ignored</code> and <code>stdin</code> to schema of <code>watchOptions</code></li>
</ul>
<hr />
<h3 id="v390httpsgithubcomwebpackwebpackreleasesv390"><a href="https://renovatebot.com/gh/webpack/webpack/releases/v3.9.0"><code>v3.9.0</code></a></h3>
<p><a href="https://renovatebot.com/gh/webpack/webpack/compare/v3.8.1…v3.9.0">Compare Source</a></p>
<h3 id="features-23">Features</h3>
<ul>
<li>add more descriptions to the schema for better validation errors</li>
<li>Handle arrow functions in AMD define/require</li>
</ul>
<h3 id="bugfixes-41">Bugfixes</h3>
<ul>
<li>added <code>stats.all</code> option to schema</li>
<li>UMD uses <code>self</code> before <code>this</code> as global object</li>
<li>Use <code>window</code> instead of this in JSONP</li>
<li>handle <code>null</code> in SourceMap correctly</li>
<li>Use Error name instead of instanceof to check for validation Error</li>
<li>Respect node.js deprecation configuration for some deprecation messages in webpack</li>
<li>Generate shorter identifiers for ConcatenatedModules to save memory</li>
<li>fix increasing delay when using HMR with <code>multiStep: true</code></li>
</ul>
<hr />
<h3 id="v381httpsgithubcomwebpackwebpackreleasesv381"><a href="https://renovatebot.com/gh/webpack/webpack/releases/v3.8.1"><code>v3.8.1</code></a></h3>
<p><a href="https://renovatebot.com/gh/webpack/webpack/compare/v3.8.0…v3.8.1">Compare Source</a></p>
<h3 id="bugfixes-42">Bugfixes:</h3>
<ul>
<li>add missing keys to <code>stats</code> schema for validation</li>
</ul>
<hr />
<h3 id="v380httpsgithubcomwebpackwebpackreleasesv380"><a href="https://renovatebot.com/gh/webpack/webpack/releases/v3.8.0"><code>v3.8.0</code></a></h3>
<p><a href="https://renovatebot.com/gh/webpack/webpack/compare/v3.7.1…v3.8.0">Compare Source</a></p>
<h3 id="features-24">Features:</h3>
<ul>
<li>It's now possible to include the <code>--env</code> data in stats (<a href="https://renovatebot.com/gh/jbottigliero">@&#8203;jbottigliero</a>)</li>
<li>There is a warning when trying to load a initial chunk with <code>import()</code> or <code>require.ensure</code> now (<a href="https://renovatebot.com/gh/sokra">@&#8203;sokra</a>)</li>
</ul>
<h3 id="bugfixes-43">Bugfixes:</h3>
<ul>
<li>fix a race condition for ENOENT errors (<a href="https://renovatebot.com/gh/simon-paris">@&#8203;simon-paris</a>)</li>
<li>chunk reasons comments are now set more consistent (<a href="https://renovatebot.com/gh/sokra">@&#8203;sokra</a>)</li>
<li>fix schema for <code>stats</code> and be more strict (<a href="https://renovatebot.com/gh/jbottigliero">@&#8203;jbottigliero</a>)<ul>
<li>This may lead to errors if you've provided wrong properties.</li></ul></li>
<li>remove the absolute path from the parser error message (<a href="https://renovatebot.com/gh/sokra">@&#8203;sokra</a>)</li>
<li>fix changed behavior when loading a initial chunk on demand (<a href="https://renovatebot.com/gh/sokra">@&#8203;sokra</a>)</li>
</ul>
<h3 id="performance-1">Performance</h3>
<ul>
<li>chunk graph is now build in breath-first traversal, which is faster (<a href="https://renovatebot.com/gh/sokra">@&#8203;sokra</a>)</li>
<li>fix a performance problem in some edge cases (<a href="https://renovatebot.com/gh/sokra">@&#8203;sokra</a>)</li>
</ul>
<hr />
<h3 id="v371httpsgithubcomwebpackwebpackreleasesv371"><a href="https://renovatebot.com/gh/webpack/webpack/releases/v3.7.1"><code>v3.7.1</code></a></h3>
<p><a href="https://renovatebot.com/gh/webpack/webpack/compare/v3.7.0…v3.7.1">Compare Source</a></p>
<h3 id="bugfixes-44">Bugfixes</h3>
<ul>
<li>fix crash for undefined optional in ExternalModule (<a href="https://renovatebot.com/gh/STRML">@&#8203;STRML</a>)</li>
</ul>
<hr />
<h3 id="v370httpsgithubcomwebpackwebpackreleasesv370"><a href="https://renovatebot.com/gh/webpack/webpack/releases/v3.7.0"><code>v3.7.0</code></a></h3>
<p><a href="https://renovatebot.com/gh/webpack/webpack/compare/v3.6.0…v3.7.0">Compare Source</a></p>
<h3 id="features-25">Features</h3>
<ul>
<li>Static analysis can now concat string with <code>.concat</code> (<a href="https://renovatebot.com/gh/loganfsmyth">@&#8203;loganfsmyth</a>)</li>
<li>add <code>ContextExclusionPlugin</code> to exclude files in a context (<a href="https://renovatebot.com/gh/timse">@&#8203;timse</a>)</li>
<li>add <code>deepChildren</code> flag to <code>CommonChunkPlugin</code> (<a href="https://renovatebot.com/gh/ArcEglos">@&#8203;ArcEglos</a>, <a href="https://renovatebot.com/gh/ljcrapo">@&#8203;ljcrapo</a>)</li>
<li>Allow using non-UMD externals combined with UMD externals (<a href="https://renovatebot.com/gh/NMinhNguyen">@&#8203;NMinhNguyen</a>)</li>
</ul>
<h3 id="bugfixes-45">Bugfixes</h3>
<ul>
<li>References to dll now contribute correctly to hash (<a href="https://renovatebot.com/gh/dtinth">@&#8203;dtinth</a>)</li>
<li>fix behavior of <code>--watch-poll</code> in CLI (<a href="https://renovatebot.com/gh/Aladdin-ADD">@&#8203;Aladdin-ADD</a>)</li>
<li>set <code>crossOrigin</code> on script tags for HMR (<a href="https://renovatebot.com/gh/STRML">@&#8203;STRML</a>)</li>
<li>fix usage of local AMD modules in AMD require (<a href="https://renovatebot.com/gh/chuckdumont">@&#8203;chuckdumont</a>)</li>
<li>show a warning when using g or y flag for context RegExp (<a href="https://renovatebot.com/gh/simon-paris">@&#8203;simon-paris</a>)</li>
<li>chunk graph should be now more correct (<a href="https://renovatebot.com/gh/sokra">@&#8203;sokra</a>)</li>
</ul>
<h3 id="performance-2">Performance</h3>
<ul>
<li>fixes a performance problem with many ESM import/exports in a module (<a href="https://renovatebot.com/gh/sokra">@&#8203;sokra</a>)</li>
<li>fixes a performance problem with heavily circular/interconnected chunks graphs (<a href="https://renovatebot.com/gh/sokra">@&#8203;sokra</a>)</li>
</ul>
<hr />
<h3 id="v360httpsgithubcomwebpackwebpackreleasesv360"><a href="https://renovatebot.com/gh/webpack/webpack/releases/v3.6.0"><code>v3.6.0</code></a></h3>
<p><a href="https://renovatebot.com/gh/webpack/webpack/compare/v3.5.6…v3.6.0">Compare Source</a></p>
<h3 id="bugfixes-46">Bugfixes</h3>
<ul>
<li>Using folder names on CLI now correctly uses folder as entry (<a href="https://renovatebot.com/gh/gyandeeps">@&#8203;gyandeeps</a>)</li>
<li>Assign correct cache object to child compiler (<a href="https://renovatebot.com/gh/sokra">@&#8203;sokra</a>)</li>
</ul>
<hr />
<h3 id="v356httpsgithubcomwebpackwebpackreleasesv356"><a href="https://renovatebot.com/gh/webpack/webpack/releases/v3.5.6"><code>v3.5.6</code></a></h3>
<p><a href="https://renovatebot.com/gh/webpack/webpack/compare/v3.5.5…v3.5.6">Compare Source</a></p>
<h3 id="bugfixes-47">Bugfixes</h3>
<ul>
<li><code>--watch-poll</code> also accepts a number now (<a href="https://renovatebot.com/gh/civalin">@&#8203;civalin</a>)</li>
<li>optimization bailout messages are now correctly cleared on incremental compilation (<a href="https://renovatebot.com/gh/STRML">@&#8203;STRML</a>)</li>
<li>(back)slashes in querystring are not correctly handled when making the request relative to context (<a href="https://renovatebot.com/gh/donocode">@&#8203;donocode</a>)</li>
<li><code>orginalError</code> -&gt; <code>originalError</code> in HMR API (<a href="https://renovatebot.com/gh/sokra">@&#8203;sokra</a>)</li>
<li>fix <code>Cannot read property '0' of undefined</code> in harmony modules (<a href="https://renovatebot.com/gh/sokra">@&#8203;sokra</a>)</li>
<li>Handle <code>require</code> to root of concatenated module correctly and don't generate <code>__webpack_require__(null)</code> (<a href="https://renovatebot.com/gh/sokra">@&#8203;sokra</a>)</li>
<li>No longer use <code>async</code> as variable name (<a href="https://renovatebot.com/gh/sokra">@&#8203;sokra</a>)</li>
<li>Object in options are now cloned when applying defaults (<a href="https://renovatebot.com/gh/sokra">@&#8203;sokra</a>)</li>
</ul>
<h3 id="performance-3">Performance</h3>
<ul>
<li>Performance improvements for SourceMap devtool (<a href="https://renovatebot.com/gh/filipesilva">@&#8203;filipesilva</a>)</li>
</ul>
<hr />
<h3 id="v355httpsgithubcomwebpackwebpackreleasesv355"><a href="https://renovatebot.com/gh/webpack/webpack/releases/v3.5.5"><code>v3.5.5</code></a></h3>
<p><a href="https://renovatebot.com/gh/webpack/webpack/compare/v3.5.4…v3.5.5">Compare Source</a></p>
<h3 id="bugfixes-48">Bugfixes:</h3>
<ul>
<li>fixes a bug where modules where incorrectly removed from chunks resulting in <code>call on undefined</code> errors (can happen when using <code>externals</code> and <code>CommonChunkPlugin</code>)</li>
<li>Modules no longer loose <code>__esModule</code> flag on incremental build with <code>ModuleConcatenationPlugin</code></li>
<li><code>__esModule</code> flag is now only set when needed with the <code>ModuleConcatenationPlugin</code></li>
</ul>
<hr />
<h3 id="v354httpsgithubcomwebpackwebpackreleasesv354"><a href="https://renovatebot.com/gh/webpack/webpack/releases/v3.5.4"><code>v3.5.4</code></a></h3>
<p><a href="https://renovatebot.com/gh/webpack/webpack/compare/v3.5.3…v3.5.4">Compare Source</a></p>
<h3 id="bugfixes-49">Bugfixes</h3>
<ul>
<li>Warnings and errors contribute to hash, which shows stats on warning-only change</li>
<li>HMR: avoid crash when calling accept handler on disposed module</li>
<li>HMR: disable Scope Hoisting for modules using HMR</li>
<li>restore backwards compatibility of ConcatenatedModule (<a href="https://renovatebot.com/gh/kisenka">@&#8203;kisenka</a>)</li>
</ul>
<h3 id="features-26">Features:</h3>
<ul>
<li>Add option to limit the number of parallel processed modules (<code>parallelism</code>)</li>
</ul>
<hr />
<h3 id="v353httpsgithubcomwebpackwebpackreleasesv353"><a href="https://renovatebot.com/gh/webpack/webpack/releases/v3.5.3"><code>v3.5.3</code></a></h3>
<p><a href="https://renovatebot.com/gh/webpack/webpack/compare/v3.5.2…v3.5.3">Compare Source</a></p>
<h3 id="bugfixes-50">Bugfixes</h3>
<ul>
<li>fixes a name conflict with the <code>ModuleConcatenationPlugin</code></li>
</ul>
<hr />
<h3 id="v352httpsgithubcomwebpackwebpackreleasesv352"><a href="https://renovatebot.com/gh/webpack/webpack/releases/v3.5.2"><code>v3.5.2</code></a></h3>
<p><a href="https://renovatebot.com/gh/webpack/webpack/compare/v3.5.1…v3.5.2">Compare Source</a></p>
<h3 id="bugfixes-51">Bugfixes:</h3>
<ul>
<li>fixes stack overflow with circular dependencies (<code>ModuleConcatenationPlugin</code>)</li>
</ul>
<hr />
<h3 id="v351httpsgithubcomwebpackwebpackreleasesv351"><a href="https://renovatebot.com/gh/webpack/webpack/releases/v3.5.1"><code>v3.5.1</code></a></h3>
<p><a href="https://renovatebot.com/gh/webpack/webpack/compare/v3.5.0…v3.5.1">Compare Source</a></p>
<h3 id="bugfixes-52">Bugfixes:</h3>
<ul>
<li>fix invalid syntax when using non-number ids with Scope Hoisting</li>
</ul>
<hr />
<h3 id="v350httpsgithubcomwebpackwebpackreleasesv350"><a href="https://renovatebot.com/gh/webpack/webpack/releases/v3.5.0"><code>v3.5.0</code></a></h3>
<p><a href="https://renovatebot.com/gh/webpack/webpack/compare/v3.4.1…v3.5.0">Compare Source</a></p>
<h3 id="features-27">Features:</h3>
<ul>
<li>add <code>stats.excludeAssets</code> to allow to filter assets in list (<a href="https://renovatebot.com/gh/ldrick">@&#8203;ldrick</a>)</li>
<li>add <code>import(/* webpackMode: "weak" */ "module")</code> to try to load a module without network request (<a href="https://renovatebot.com/gh/faceyspacey">@&#8203;faceyspacey</a>)</li>
<li>add 4. argument to <code>require.context</code> which is the context mode. Can be <code>false</code>, <code>"eager"</code>, <code>"lazy-once"</code>, <code>"weak"</code> and <code>"async-weak"</code>. (<a href="https://renovatebot.com/gh/faceyspacey">@&#8203;faceyspacey</a>)</li>
<li><code>require.resolveWeak</code> now support expressions (<a href="https://renovatebot.com/gh/faceyspacey">@&#8203;faceyspacey</a>)</li>
<li>generate only a single require for modules references in scope-hoisted modules (<code>ModuleConcatenationPlugin</code>)</li>
</ul>
<h3 id="bugfixes-53">Bugfixes:</h3>
<ul>
<li>keep correct import order when using the <code>ModuleConcatenationPlugin</code></li>
<li>Generate shorter, more readable identifiers in <code>ConcatenatedModule</code></li>
<li><code>--help</code> output is flushed before process exit (<a href="https://renovatebot.com/gh/esbenp">@&#8203;esbenp</a>)</li>
<li>exit code is reliable reported for CLI validation error (<a href="https://renovatebot.com/gh/polomsky">@&#8203;polomsky</a>)</li>
<li><code>stats</code> options are now validated by schema (<a href="https://renovatebot.com/gh/esbenp">@&#8203;esbenp</a>)</li>
<li>fixes problem when using the <code>CommonsChunkPlugin</code> in async mode without <code>name</code> argument</li>
<li>fixes description of <code>--resolve-extensions</code> (<a href="https://renovatebot.com/gh/tomek-d">@&#8203;tomek-d</a>)</li>
<li>fixes <code>has no internal name</code> when using dependency variable in root of scope-hoisted modules (<code>ModuleConcatenationPlugin</code>)</li>
</ul>
<h3 id="examples">Examples:</h3>
<ul>
<li>add an example for dll + app (<a href="https://renovatebot.com/gh/aretecode">@&#8203;aretecode</a>)</li>
</ul>
<hr />
<h3 id="v341httpsgithubcomwebpackwebpackreleasesv341"><a href="https://renovatebot.com/gh/webpack/webpack/releases/v3.4.1"><code>v3.4.1</code></a></h3>
<p><a href="https://renovatebot.com/gh/webpack/webpack/compare/v3.4.0…v3.4.1">Compare Source</a></p>
<h3 id="bugfixes-54">Bugfixes:</h3>
<ul>
<li>fix incorrect warnings about exports when using the DllReferencePlugin</li>
</ul>
<hr />
<h3 id="v340httpsgithubcomwebpackwebpackreleasesv340"><a href="https://renovatebot.com/gh/webpack/webpack/releases/v3.4.0"><code>v3.4.0</code></a></h3>
<p><a href="https://renovatebot.com/gh/webpack/webpack/compare/v3.3.0…v3.4.0">Compare Source</a></p>
<h3 id="features-28">Features:</h3>
<ul>
<li>Improved optimization bailout messages</li>
<li>NamedModulesPlugins and HashedModuleIdsPlugin work now properly with delegated modules (DllReferencePlugin) and externals.</li>
<li>add <code>--config-name</code> option to choose a config by name for compiling a part of the config</li>
<li>Improved error message when parsing in ModuleConcatenationPlug