### PR TITLE
Update dependency style-loader to ^0.23.0

### DIFF
--- a/Examples/xc.chat/webapp/package.json
+++ b/Examples/xc.chat/webapp/package.json
@@ -89,7 +89,7 @@
     "node-sass": "^4.0.0",
     "sass-loader": "^7.0.0",
     "source-map-loader": "^0.2.0",
-    "style-loader": "^0.22.0",
+    "style-loader": "^0.23.0",
     "ts-jest": "^23.0.0",
     "ts-loader": "^2.0.0",
     "tslint": "^4.1.0",

--- a/Examples/xc.chat/webapp/yarn.lock
+++ b/Examples/xc.chat/webapp/yarn.lock
@@ -7297,9 +7297,9 @@ strip-outer@^1.0.0:
   dependencies:
     escape-string-regexp "^1.0.2"
 
-style-loader@^0.22.0:
-  version "0.22.0"
-  resolved "https://registry.yarnpkg.com/style-loader/-/style-loader-0.22.0.tgz#2044d96156f454cc37b61f98eb49980239f4b8eb"
+style-loader@^0.23.0:
+  version "0.23.0"
+  resolved "https://registry.yarnpkg.com/style-loader/-/style-loader-0.23.0.tgz#8377fefab68416a2e05f1cabd8c3a3acfcce74f1"
   dependencies:
     loader-utils "^1.1.0"
     schema-utils "^0.4.5"


### PR DESCRIPTION
<p>This Pull Request updates dependency <a href="https://renovatebot.com/gh/webpack-contrib/style-loader">style-loader</a> from <code>^0.22.0</code> to <code>^0.23.0</code></p>
<p><details><br />
<summary>Release Notes</summary></p>
<h3 id="v0230httpsgithubcomwebpack-contribstyle-loaderblobmasterchangelogmd82030230httpsgithubcomwebpack-contribstyle-loadercomparev0221v0230-2018-08-27"><a href="https://renovatebot.com/gh/webpack-contrib/style-loader/blob/master/CHANGELOG.md#&#8203;0230httpsgithubcomwebpack-contribstyle-loadercomparev0221v0230-2018-08-27"><code>v0.23.0</code></a></h3>
<p><a href="https://renovatebot.com/gh/webpack-contrib/style-loader/compare/v0.22.1…v0.23.0">Compare Source</a></p>
<h5 id="features">Features</h5>
<ul>
<li><strong>useable:</strong> add <code>insertInto</code> support (<code>options.insertInto</code>) (<a href="https://renovatebot.com/gh/webpack-contrib/style-loader/issues/341">#&#8203;341</a>) (<a href="https://renovatebot.com/gh/webpack-contrib/style-loader/commit/2588aca">2588aca</a>)</li>
</ul>
<h4 id="0221httpsgithubcomwebpack-contribstyle-loadercomparev0220v0221-2018-08-08"><a href="https://renovatebot.com/gh/webpack-contrib/style-loader/compare/v0.22.0…v0.22.1">0.22.1</a> (2018-08-08)</h4>
<h5 id="bug-fixes">Bug Fixes</h5>
<ul>
<li><strong>addStyles:</strong> use <code>var</code> instead of <code>const</code> (IE fix) (<a href="https://renovatebot.com/gh/webpack-contrib/style-loader/issues/338">#&#8203;338</a>) (<a href="https://renovatebot.com/gh/webpack-contrib/style-loader/commit/1ca12ab">1ca12ab</a>)</li>
</ul>
<hr />
<p></details></p>
<hr />
<p>This PR has been generated by <a href="https://renovatebot.com">Renovate Bot</a>.</p>