### PR TITLE
Update dependency babel-loader to v8

### DIFF
--- a/Examples/xc.chat/webapp/package.json
+++ b/Examples/xc.chat/webapp/package.json
@@ -71,7 +71,7 @@
   "devDependencies": {
     "@types/deep-freeze": "0.1.1",
     "babel-core": "^6.11.4",
-    "babel-loader": "^7.0.0",
+    "babel-loader": "^8.0.0",
     "clean-webpack-plugin": "^0.1.14",
     "compression": "^1.6.2",
     "css-loader": "^1.0.0",

--- a/Examples/xc.chat/webapp/yarn.lock
+++ b/Examples/xc.chat/webapp/yarn.lock
@@ -570,13 +570,14 @@ babel-jest@^23.4.2:
     babel-plugin-istanbul "^4.1.6"
     babel-preset-jest "^23.2.0"
 
-babel-loader@^7.0.0:
-  version "7.1.5"
-  resolved "https://registry.yarnpkg.com/babel-loader/-/babel-loader-7.1.5.tgz#e3ee0cd7394aa557e013b02d3e492bfd07aa6d68"
+babel-loader@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/babel-loader/-/babel-loader-8.0.0.tgz#c42f2bef268d0d8bb4ceec5d02b540a9055d58a0"
   dependencies:
     find-cache-dir "^1.0.0"
     loader-utils "^1.0.2"
     mkdirp "^0.5.1"
+    util.promisify "^1.0.0"
 
 babel-messages@^6.23.0:
   version "6.23.0"


### PR DESCRIPTION
<p>This Pull Request updates dependency <a href="https://renovatebot.com/gh/babel/babel-loader">babel-loader</a> from <code>^7.0.0</code> to <code>^8.0.0</code></p>
<p><details><br />
<summary>Release Notes</summary></p>
<h3 id="v800httpsgithubcombabelbabel-loaderreleasesv800"><a href="https://renovatebot.com/gh/babel/babel-loader/releases/v8.0.0">v8.0.0</a></h3>
<p><a href="https://renovatebot.com/gh/babel/babel-loader/compare/v7.1.5…v8.0.0">Compare Source</a><br />
This is the first stable release of <code>babel-loader</code> for Babel 7.x.</p>
<ul>
<li>README updates</li>
<li>Dropped peer dependency on betas and RCs, but left the backward-compat code we had for now to give people time to migrate</li>
</ul>
<hr />
<p></details></p>
<hr />
<p>This PR has been generated by <a href="https://renovatebot.com">Renovate Bot</a>.</p>