### PR TITLE
Update dependency ts-loader to v5

### DIFF
--- a/Examples/xc.chat/webapp/package.json
+++ b/Examples/xc.chat/webapp/package.json
@@ -91,7 +91,7 @@
     "source-map-loader": "^0.2.0",
     "style-loader": "^0.23.0",
     "ts-jest": "^23.0.0",
-    "ts-loader": "^2.0.0",
+    "ts-loader": "^5.0.0",
     "tslint": "^4.1.0",
     "tslint-loader": "^3.3.0",
     "typescript": "^3.0.0",

--- a/Examples/xc.chat/webapp/yarn.lock
+++ b/Examples/xc.chat/webapp/yarn.lock
@@ -2326,15 +2326,6 @@ end-of-stream@^1.1.0:
   dependencies:
     once "^1.4.0"
 
-enhanced-resolve@^3.0.0:
-  version "3.4.1"
-  resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-3.4.1.tgz#0421e339fd71419b3da13d129b3979040230476e"
-  dependencies:
-    graceful-fs "^4.1.2"
-    memory-fs "^0.4.0"
-    object-assign "^4.0.1"
-    tapable "^0.2.7"
-
 enhanced-resolve@^4.0.0, enhanced-resolve@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-4.1.0.tgz#41c7e0bfdfe74ac1ffe1e57ad6a5c6c9f3742a7f"
@@ -7728,10 +7719,6 @@ symbol-tree@^3.2.2:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.2.tgz#ae27db38f660a7ae2e1c3b7d1bc290819b8519e6"
 
-tapable@^0.2.7:
-  version "0.2.8"
-  resolved "https://registry.yarnpkg.com/tapable/-/tapable-0.2.8.tgz#99372a5c999bf2df160afc0d74bed4f47948cd22"
-
 tapable@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-1.0.0.tgz#cbb639d9002eed9c6b5975eb20598d7936f1f9f2"
@@ -7969,13 +7956,14 @@ ts-jest@^23.0.0:
     fs-extra "6.0.1"
     lodash "^4.17.10"
 
-ts-loader@^2.0.0:
-  version "2.3.7"
-  resolved "https://registry.yarnpkg.com/ts-loader/-/ts-loader-2.3.7.tgz#a9028ced473bee12f28a75f9c5b139979d33f2fc"
+ts-loader@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/ts-loader/-/ts-loader-5.0.0.tgz#0715ee31ed229fcdc8df73e87ccd80e6a46cae04"
   dependencies:
-    chalk "^2.0.1"
-    enhanced-resolve "^3.0.0"
+    chalk "^2.3.0"
+    enhanced-resolve "^4.0.0"
     loader-utils "^1.0.2"
+    micromatch "^3.1.4"
     semver "^5.0.1"
 
 tslib@^1.9.0:


### PR DESCRIPTION
<p>This Pull Request updates dependency <a href="https://renovatebot.com/gh/TypeStrong/ts-loader">ts-loader</a> from <code>^2.0.0</code> to <code>^5.0.0</code></p>
<p><details><br />
<summary>Release Notes</summary></p>
<h3 id="v500httpsgithubcomtypestrongts-loaderblobmasterchangelogmd8203500"><a href="https://renovatebot.com/gh/TypeStrong/ts-loader/blob/master/CHANGELOG.md#&#8203;500"><code>v5.0.0</code></a></h3>
<p><a href="https://renovatebot.com/gh/TypeStrong/ts-loader/compare/v4.5.0…v5.0.0">Compare Source</a></p>
<ul>
<li><a href="https://renovatebot.com/gh/TypeStrong/ts-loader/pull/822">feat: Fixed issue with incorrect output path for declaration files</a> - thanks <a href="https://renovatebot.com/gh/JonWallsten">@&#8203;JonWallsten</a>! <strong>BREAKING CHANGE</strong></li>
</ul>
<hr />
<h3 id="v450httpsgithubcomtypestrongts-loaderblobmasterchangelogmd8203450"><a href="https://renovatebot.com/gh/TypeStrong/ts-loader/blob/master/CHANGELOG.md#&#8203;450"><code>v4.5.0</code></a></h3>
<p><a href="https://renovatebot.com/gh/TypeStrong/ts-loader/compare/v4.4.2…v4.5.0">Compare Source</a></p>
<ul>
<li><a href="https://renovatebot.com/gh/TypeStrong/ts-loader/pull/821">feat: Added support for TypeScript declaration map</a> - thanks <a href="https://renovatebot.com/gh/JonWallsten">@&#8203;JonWallsten</a>!</li>
</ul>
<hr />
<h3 id="v442httpsgithubcomtypestrongts-loaderblobmasterchangelogmd8203442"><a href="https://renovatebot.com/gh/TypeStrong/ts-loader/blob/master/CHANGELOG.md#&#8203;442"><code>v4.4.2</code></a></h3>
<p><a href="https://renovatebot.com/gh/TypeStrong/ts-loader/compare/v4.4.1…v4.4.2">Compare Source</a></p>
<ul>
<li><a href="https://renovatebot.com/gh/TypeStrong/ts-loader/pull/792">fix(loader): new Error to webpack when errors occured in the loader function</a> - thanks <a href="https://renovatebot.com/gh/linxiaowu66">@&#8203;linxiaowu66</a> and <a href="https://renovatebot.com/gh/systemmetaphor">@&#8203;systemmetaphor</a>!</li>
</ul>
<hr />
<h3 id="v441httpsgithubcomtypestrongts-loaderblobmasterchangelogmd8203441"><a href="https://renovatebot.com/gh/TypeStrong/ts-loader/blob/master/CHANGELOG.md#&#8203;441"><code>v4.4.1</code></a></h3>
<p><a href="https://renovatebot.com/gh/TypeStrong/ts-loader/compare/v4.4.0…v4.4.1">Compare Source</a></p>
<ul>
<li><a href="https://renovatebot.com/gh/TypeStrong/ts-loader/pull/790">fix(types): expose public interfaces from root index.d.ts</a> - thanks <a href="https://renovatebot.com/gh/Hotell">@&#8203;Hotell</a>!</li>
</ul>
<hr />
<h3 id="v440httpsgithubcomtypestrongts-loaderblobmasterchangelogmd8203440"><a href="https://renovatebot.com/gh/TypeStrong/ts-loader/blob/master/CHANGELOG.md#&#8203;440"><code>v4.4.0</code></a></h3>
<p><a href="https://renovatebot.com/gh/TypeStrong/ts-loader/compare/v4.3.1…v4.4.0">Compare Source</a></p>
<ul>
<li><a href="https://renovatebot.com/gh/TypeStrong/ts-loader/pull/788">feat: generate ambient types from implementation</a> - thanks <a href="https://renovatebot.com/gh/Hotell">@&#8203;Hotell</a>!</li>
<li><a href="https://renovatebot.com/gh/TypeStrong/ts-loader/pull/786">error when not using webpack 4</a> - thanks <a href="https://renovatebot.com/gh/johnnyreilly">@&#8203;johnnyreilly</a></li>
</ul>
<hr />
<h3 id="v431httpsgithubcomtypestrongts-loaderblobmasterchangelogmd8203431"><a href="https://renovatebot.com/gh/TypeStrong/ts-loader/blob/master/CHANGELOG.md#&#8203;431"><code>v4.3.1</code></a></h3>
<p><a href="https://renovatebot.com/gh/TypeStrong/ts-loader/compare/v4.3.0…v4.3.1">Compare Source</a></p>
<ul>
<li><a href="https://renovatebot.com/gh/TypeStrong/ts-loader/pull/782">Fix options caching when ts-loader is used in multiple rules</a> - thanks <a href="https://renovatebot.com/gh/yyx990803">@&#8203;yyx990803</a>!</li>
</ul>
<p>Please note, this bug fix requires that vue-loader users still using v14 should either upgrade to v15 or explicitly pass the same ts-loader options via v14's loaders option.  <a href="https://renovatebot.com/gh/TypeStrong/ts-loader/pull/782#issuecomment-394406093">See more details here</a></p>
<hr />
<h3 id="v430httpsgithubcomtypestrongts-loaderblobmasterchangelogmd8203430"><a href="https://renovatebot.com/gh/TypeStrong/ts-loader/blob/master/CHANGELOG.md#&#8203;430"><code>v4.3.0</code></a></h3>
<p><a href="https://renovatebot.com/gh/TypeStrong/ts-loader/compare/v4.2.0…v4.3.0">Compare Source</a></p>
<ul>
<li><a href="https://renovatebot.com/gh/TypeStrong/ts-loader/pull/774">Fix dependency resolution when using pnpm</a> - thanks <a href="https://renovatebot.com/gh/xbtsw">@&#8203;xbtsw</a> and <a href="https://renovatebot.com/gh/zkochan">@&#8203;zkochan</a>!</li>
<li><a href="https://renovatebot.com/gh/TypeStrong/ts-loader/pull/773">Add <code>allowTsInNodeModules</code> option for importing .ts files from node_modules</a> - thanks <a href="https://renovatebot.com/gh/aelawson">@&#8203;aelawson</a>!</li>
</ul>
<hr />
<h3 id="v420httpsgithubcomtypestrongts-loaderblobmasterchangelogmd8203420"><a href="https://renovatebot.com/gh/TypeStrong/ts-loader/blob/master/CHANGELOG.md#&#8203;420"><code>v4.2.0</code></a></h3>
<p><a href="https://renovatebot.com/gh/TypeStrong/ts-loader/compare/v4.1.0…v4.2.0">Compare Source</a></p>
<ul>
<li><a href="https://renovatebot.com/gh/TypeStrong/ts-loader/pull/756">Pass `context' to error formatters</a> - thanks <a href="https://renovatebot.com/gh/gustavderdrache">@&#8203;gustavderdrache</a>!</li>
</ul>
<hr />
<h3 id="v410httpsgithubcomtypestrongts-loaderblobmasterchangelogmdv410"><a href="https://renovatebot.com/gh/TypeStrong/ts-loader/blob/master/CHANGELOG.md#v410"><code>v4.1.0</code></a></h3>
<p><a href="https://renovatebot.com/gh/TypeStrong/ts-loader/compare/v4.0.1…v4.1.0">Compare Source</a></p>
<ul>
<li><a href="https://renovatebot.com/gh/TypeStrong/ts-loader/pull/747">Fix slow <code>experimentalWatchApi</code></a> (<a href="https://renovatebot.com/gh/TypeStrong/ts-loader/issues/746">#&#8203;746</a>) - thanks <a href="https://renovatebot.com/gh/sheetalkamat">@&#8203;sheetalkamat</a> and <a href="https://renovatebot.com/gh/MLoughry">@&#8203;MLoughry</a>!</li>
<li><a href="https://renovatebot.com/gh/TypeStrong/ts-loader/pull/745">feat: <code>getCustomTransformers</code> support path string for a module</a> - thanks <a href="https://renovatebot.com/gh/vagusX">@&#8203;vagusX</a> and <a href="https://renovatebot.com/gh/s-panferov">@&#8203;s-panferov</a> (upon whose work this is based I believe)</li>
</ul>
<hr />
<h3 id="v401httpsgithubcomtypestrongts-loaderblobmasterchangelogmdv401"><a href="https://renovatebot.com/gh/TypeStrong/ts-loader/blob/master/CHANGELOG.md#v401"><code>v4.0.1</code></a></h3>
<p><a href="https://renovatebot.com/gh/TypeStrong/ts-loader/compare/v4.0.0…v4.0.1">Compare Source</a></p>
<ul>
<li><a href="https://renovatebot.com/gh/TypeStrong/ts-loader/pull/737">Fix name collision in experimentalWatchApi code</a> - thanks <a href="https://renovatebot.com/gh/MLoughry">@&#8203;MLoughry</a>!</li>
</ul>
<hr />
<h3 id="v400httpsgithubcomtypestrongts-loaderblobmasterchangelogmdv400"><a href="https://renovatebot.com/gh/TypeStrong/ts-loader/blob/master/CHANGELOG.md#v400"><code>v4.0.0</code></a></h3>
<p><a href="https://renovatebot.com/gh/TypeStrong/ts-loader/compare/v3.5.0…v4.0.0">Compare Source</a></p>
<ul>
<li>Support webpack 4</li>
<li>Drop support for webpack 2/3 <strong>BREAKING CHANGE</strong> - use ts-loader 3.x if you need webpack 2/3 support</li>
<li>Minimum TypeScript version is now 2.4.1 <strong>BREAKING CHANGE</strong></li>
<li>Deprecated option <code>entryFileCannotBeJs</code> removed' <strong>BREAKING CHANGE</strong></li>
<li>Start using <a href="https://prettier.io/">prettier</a> for the codebase</li>
</ul>
<hr />
<h3 id="v350httpsgithubcomtypestrongts-loaderblobmasterchangelogmdv350"><a href="https://renovatebot.com/gh/TypeStrong/ts-loader/blob/master/CHANGELOG.md#v350"><code>v3.5.0</code></a></h3>
<p><a href="https://renovatebot.com/gh/TypeStrong/ts-loader/compare/v3.4.0…v3.5.0">Compare Source</a></p>
<ul>
<li><a href="https://renovatebot.com/gh/TypeStrong/ts-loader/pull/721">Add trace for traceResolution</a> - thanks <a href="https://renovatebot.com/gh/onigoetz">@&#8203;onigoetz</a>!</li>
</ul>
<hr />
<h3 id="v340httpsgithubcomtypestrongts-loaderblobmasterchangelogmdv340"><a href="https://renovatebot.com/gh/TypeStrong/ts-loader/blob/master/CHANGELOG.md#v340"><code>v3.4.0</code></a></h3>
<p><a href="https://renovatebot.com/gh/TypeStrong/ts-loader/compare/v3.3.1…v3.4.0">Compare Source</a></p>
<ul>
<li><a href="https://renovatebot.com/gh/TypeStrong/ts-loader/pull/698">local .d.ts files now marked as changed when watch is triggered</a> - thanks <a href="https://renovatebot.com/gh/KnisterPeter">@&#8203;KnisterPeter</a>!</li>
</ul>
<hr />
<h3 id="v331httpsgithubcomtypestrongts-loaderblobmasterchangelogmdv331"><a href="https://renovatebot.com/gh/TypeStrong/ts-loader/blob/master/CHANGELOG.md#v331"><code>v3.3.1</code></a></h3>
<p><a href="https://renovatebot.com/gh/TypeStrong/ts-loader/compare/v3.3.0…v3.3.1">Compare Source</a></p>
<ul>
<li><a href="https://renovatebot.com/gh/TypeStrong/ts-loader/pull/715">Fixes to support watch api for compiling - lib support etc</a> - thanks <a href="https://renovatebot.com/gh/sheetalkamat">@&#8203;sheetalkamat</a>!</li>
</ul>
<hr />
<h3 id="v330httpsgithubcomtypestrongts-loaderblobmasterchangelogmdv330"><a href="https://renovatebot.com/gh/TypeStrong/ts-loader/blob/master/CHANGELOG.md#v330"><code>v3.3.0</code></a></h3>
<p><a href="https://renovatebot.com/gh/TypeStrong/ts-loader/compare/v3.2.0…v3.3.0">Compare Source</a></p>
<ul>
<li><a href="https://renovatebot.com/gh/TypeStrong/ts-loader/pull/701">Report diagnostics only on certain files with <code>reportFiles</code> option</a> - thanks <a href="https://renovatebot.com/gh/freeman">@&#8203;freeman</a>!</li>
<li><a href="https://renovatebot.com/gh/TypeStrong/ts-loader/pull/688/">Replaced option <code>contextAsConfigBasePath</code> with <code>context</code> option.</a> Strictly speaking a breaking change. However, given the original option was never able to fulfil its intended purpose I've decided to treat this as just a new feature; there seems no possibility that anyone can be using <code>contextAsConfigBasePath</code> - thanks <a href="https://renovatebot.com/gh/christiantinauer">@&#8203;christiantinauer</a>!</li>
<li><a href="https://renovatebot.com/gh/TypeStrong/ts-loader/pull/685">Added support for the new watch api of TypeScript compiler.</a> nb This feature has been placed behind a new <code>experimentalWatchApi</code> option until it has been thoroughly tested. All being well it is likely to become the default behaviour for ts-loader in future - thanks <a href="https://renovatebot.com/gh/sheetalkamat">@&#8203;sheetalkamat</a>!</li>
</ul>
<hr />
<h3 id="v320httpsgithubcomtypestrongts-loaderblobmasterchangelogmdv320"><a href="https://renovatebot.com/gh/TypeStrong/ts-loader/blob/master/CHANGELOG.md#v320"><code>v3.2.0</code></a></h3>
<p><a href="https://renovatebot.com/gh/TypeStrong/ts-loader/compare/v3.1.1…v3.2.0">Compare Source</a></p>
<ul>
<li><a href="https://renovatebot.com/gh/TypeStrong/ts-loader/pull/681">Add new loader option <code>contextAsConfigBasePath</code></a> - thanks <a href="https://renovatebot.com/gh/christiantinauer">@&#8203;christiantinauer</a></li>
</ul>
<hr />
<h3 id="v311httpsgithubcomtypestrongts-loaderblobmasterchangelogmdv311"><a href="https://renovatebot.com/gh/TypeStrong/ts-loader/blob/master/CHANGELOG.md#v311"><code>v3.1.1</code></a></h3>
<p><a href="https://renovatebot.com/gh/TypeStrong/ts-loader/compare/v3.1.0…v3.1.1">Compare Source</a></p>
<ul>
<li><a href="https://renovatebot.com/gh/TypeStrong/ts-loader/pull/674">Fix error importing buildt ts files with allowJs</a> (<a href="https://renovatebot.com/gh/TypeStrong/ts-loader/issues/667">#&#8203;667</a>) - thanks <a href="https://renovatebot.com/gh/Pajn">@&#8203;Pajn</a>!</li>
</ul>
<hr />
<h3 id="v310httpsgithubcomtypestrongts-loaderblobmasterchangelogmdv310"><a href="https://renovatebot.com/gh/TypeStrong/ts-loader/blob/master/CHANGELOG.md#v310"><code>v3.1.0</code></a></h3>
<p><a href="https://renovatebot.com/gh/TypeStrong/ts-loader/compare/v3.0.5…v3.1.0">Compare Source</a></p>
<ul>
<li><a href="https://renovatebot.com/gh/TypeStrong/ts-loader/pull/671">Add <code>onlyCompileBundledFiles</code> option which modifies behaviour to load only those files that are actually bundled by webpack</a> <a href="https://renovatebot.com/gh/TypeStrong/ts-loader/issues/267">#&#8203;267</a> - thanks <a href="https://renovatebot.com/gh/maier49">@&#8203;maier49</a>!</li>
<li><a href="https://renovatebot.com/gh/TypeStrong/ts-loader/issues/664">Chore release; upgraded chalk dependency in <code>package.json</code> to 2.3, as 2.3 is another breaking changes release (from a TypeScript perspective).</a>, see <a href="https://renovatebot.com/gh/chalk/chalk/issues/215">here</a> for context - thanks <a href="https://renovatebot.com/gh/johnnyreilly">@&#8203;johnnyreilly</a></li>
</ul>
<hr />
<h3 id="v305httpsgithubcomtypestrongts-loaderblobmasterchangelogmdv305"><a href="https://renovatebot.com/gh/TypeStrong/ts-loader/blob/master/CHANGELOG.md#v305"><code>v3.0.5</code></a></h3>
<p><a href="https://renovatebot.com/gh/TypeStrong/ts-loader/compare/v3.0.4…v3.0.5">Compare Source</a></p>
<ul>
<li><a href="https://renovatebot.com/gh/TypeStrong/ts-loader/issues/664">Chore release; upgraded chalk dependency in <code>package.json</code> to 2.2, as 2.2 appears to be a breaking changes release.</a> - thanks <a href="https://renovatebot.com/gh/lmk123">@&#8203;lmk123</a> for reporting</li>
</ul>
<hr />
<h3 id="v304httpsgithubcomtypestrongts-loaderblobmasterchangelogmdv304"><a href="https://renovatebot.com/gh/TypeStrong/ts-loader/blob/master/CHANGELOG.md#v304"><code>v3.0.4</code></a></h3>
<p><a href="https://renovatebot.com/gh/TypeStrong/ts-loader/compare/v3.0.3…v3.0.4">Compare Source</a></p>
<ul>
<li><a href="https://renovatebot.com/gh/TypeStrong/ts-loader/pull/662">Chore release; upgraded chalk dependency.</a> - thanks <a href="https://renovatebot.com/gh/johnnyreilly">@&#8203;johnnyreilly</a></li>
</ul>
<hr />
<h3 id="v303httpsgithubcomtypestrongts-loaderblobmasterchangelogmdv303"><a href="https://renovatebot.com/gh/TypeStrong/ts-loader/blob/master/CHANGELOG.md#v303"><code>v3.0.3</code></a></h3>
<p><a href="https://renovatebot.com/gh/TypeStrong/ts-loader/compare/43480251ca5c2147bd2004c8523bc98280dc3e74…v3.0.3">Compare Source</a></p>
<ul>
<li><a href="https://renovatebot.com/gh/TypeStrong/ts-loader/pull/658">Fix allowJs @&#8203;types resolution error</a> (<a href="https://renovatebot.com/gh/TypeStrong/ts-loader/issues/657">#&#8203;657</a>, <a href="https://renovatebot.com/gh/TypeStrong/ts-loader/issues/655">#&#8203;655</a>) - thanks <a href="https://renovatebot.com/gh/johnnyreilly">@&#8203;johnnyreilly</a> and <a href="https://renovatebot.com/gh/roddypratt">@&#8203;roddypratt</a> + <a href="https://renovatebot.com/gh/ldrick">@&#8203;ldrick</a> for providing minimal repro repos which allowed me to fix this long standing bug!</li>
</ul>
<p>This fix resolves the issue for TypeScript 2.4+ (which is likely 95% of users). For those people stuck on 2.3 or below and impacted by this issue, you should be able to workaround this by setting <code>entryFileCannotBeJs: true</code> in your ts-loader options. This option should be considered deprecated as of this release. The option will likely disappear with the next major version of ts-loader which will drop support for TypeScript 2.3 and below, thus removing the need for this option.</p>
<hr />
<h3 id="v302httpsgithubcomtypestrongts-loadercomparev23743480251ca5c2147bd2004c8523bc98280dc3e74"><a href="https://renovatebot.com/gh/TypeStrong/ts-loader/compare/v2.3.7…43480251ca5c2147bd2004c8523bc98280dc3e74"><code>v3.0.2</code></a></h3>
<p><a href="https://renovatebot.com/gh/TypeStrong/ts-loader/compare/v2.3.7…43480251ca5c2147bd2004c8523bc98280dc3e74">Compare Source</a></p>
<hr />
<p></details></p>
<hr />
<p>This PR has been generated by <a href="https://renovatebot.com">Renovate Bot</a>.</p>