### PR TITLE
Update dependency @types/react-redux to v6.0.7

### DIFF
--- a/Examples/xc.chat/webapp/package.json
+++ b/Examples/xc.chat/webapp/package.json
@@ -44,7 +44,7 @@
     "@types/react": "^16.0.0",
     "@types/react-dom": "^16.0.3",
     "@types/react-intl": "^2.2.3",
-    "@types/react-redux": "6.0.6",
+    "@types/react-redux": "6.0.7",
     "@types/react-router": "^4.0.0",
     "classnames": "^2.2.5",
     "es6-promisify": "^6.0.0",

--- a/Examples/xc.chat/webapp/yarn.lock
+++ b/Examples/xc.chat/webapp/yarn.lock
@@ -63,9 +63,9 @@
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/@types/react-intl/-/react-intl-2.3.2.tgz#a57433871dedf2f12ba8eeca645e5ce5a37d102a"
 
-"@types/react-redux@6.0.6":
-  version "6.0.6"
-  resolved "https://registry.yarnpkg.com/@types/react-redux/-/react-redux-6.0.6.tgz#87f1d0a6ea901b93fcaf95fa57641ff64079d277"
+"@types/react-redux@6.0.7":
+  version "6.0.7"
+  resolved "https://registry.yarnpkg.com/@types/react-redux/-/react-redux-6.0.7.tgz#ac61cd8d137ca7205b831d66e279f42fe2a1c3cd"
   dependencies:
     "@types/react" "*"
     redux "^4.0.0"


### PR DESCRIPTION
<p>This Pull Request updates dependency <a href="https://renovatebot.com/gh/DefinitelyTyped/DefinitelyTyped">@&#8203;types/react-redux</a> from <code>v6.0.6</code> to <code>v6.0.7</code></p>
<p><details><br />
<summary>Release Notes</summary></p>
<h3 id="v607httpsgithubcomdefinitelytypeddefinitelytypedcompare7c33a958277e53aa335dcddec28ebfe6502638cac61d25db3b9e328067392983fa54691b3ee51fa4"><a href="https://renovatebot.com/gh/DefinitelyTyped/DefinitelyTyped/compare/7c33a958277e53aa335dcddec28ebfe6502638ca…c61d25db3b9e328067392983fa54691b3ee51fa4"><code>v6.0.7</code></a></h3>
<p><a href="https://renovatebot.com/gh/DefinitelyTyped/DefinitelyTyped/compare/7c33a958277e53aa335dcddec28ebfe6502638ca…c61d25db3b9e328067392983fa54691b3ee51fa4">Compare Source</a></p>
<hr />
<p></details></p>
<hr />
<p>This PR has been generated by <a href="https://renovatebot.com">Renovate Bot</a>.</p>