### PR TITLE
Update dependency @types/react-redux to v6.0.9

### DIFF
--- a/Examples/xc.chat/webapp/package.json
+++ b/Examples/xc.chat/webapp/package.json
@@ -44,7 +44,7 @@
     "@types/react": "^16.0.0",
     "@types/react-dom": "^16.0.3",
     "@types/react-intl": "^2.2.3",
-    "@types/react-redux": "6.0.8",
+    "@types/react-redux": "6.0.9",
     "@types/react-router": "^4.0.0",
     "classnames": "^2.2.5",
     "es6-promisify": "^6.0.0",

--- a/Examples/xc.chat/webapp/yarn.lock
+++ b/Examples/xc.chat/webapp/yarn.lock
@@ -63,9 +63,9 @@
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/@types/react-intl/-/react-intl-2.3.2.tgz#a57433871dedf2f12ba8eeca645e5ce5a37d102a"
 
-"@types/react-redux@6.0.8":
-  version "6.0.8"
-  resolved "https://registry.yarnpkg.com/@types/react-redux/-/react-redux-6.0.8.tgz#29c884174516f0cfab6638d2236fd7d53f45640e"
+"@types/react-redux@6.0.9":
+  version "6.0.9"
+  resolved "https://registry.yarnpkg.com/@types/react-redux/-/react-redux-6.0.9.tgz#96aa7f5b0716bcc3bfb36ceaa1223118d509f79a"
   dependencies:
     "@types/react" "*"
     redux "^4.0.0"


### PR DESCRIPTION
<p>This Pull Request updates dependency <a href="https://renovatebot.com/gh/DefinitelyTyped/DefinitelyTyped">@&#8203;types/react-redux</a> from <code>v6.0.8</code> to <code>v6.0.9</code></p>
<p><details><br />
<summary>Release Notes</summary></p>
<h3 id="v609httpsgithubcomdefinitelytypeddefinitelytypedcompareb883a3573a577355036114e6071166d1dc2fa05c972309a84a5e719a7be994a2c2f08dbddf7e2b3f"><a href="https://renovatebot.com/gh/DefinitelyTyped/DefinitelyTyped/compare/b883a3573a577355036114e6071166d1dc2fa05c…972309a84a5e719a7be994a2c2f08dbddf7e2b3f"><code>v6.0.9</code></a></h3>
<p><a href="https://renovatebot.com/gh/DefinitelyTyped/DefinitelyTyped/compare/b883a3573a577355036114e6071166d1dc2fa05c…972309a84a5e719a7be994a2c2f08dbddf7e2b3f">Compare Source</a></p>
<hr />
<p></details></p>
<hr />
<p>This PR has been generated by <a href="https://renovatebot.com">Renovate Bot</a>.</p>